### PR TITLE
ci: required PR checks + nightly integration/scan workflow (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets
+      # --all-targets excludes doctests (a cargo limitation, not a typo);
+      # run them as a separate step so a broken doc example still fails CI.
+      - run: cargo test --workspace --doc
 
   docs:
     name: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Single source of truth for the pinned version used *in CI*; keep in
+  # sync with rust-toolchain.toml's channel (that file is what local
+  # `cargo`/`rustup` pick up automatically — dtolnay/rust-toolchain does
+  # not read it and requires an explicit `toolchain` input).
+  RUST_TOOLCHAIN: "1.96.1"
 
 jobs:
   fmt:
@@ -31,6 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt
       - run: cargo fmt --all --check
 
   clippy:
@@ -39,6 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
@@ -49,6 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets
 
@@ -58,6 +71,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps --workspace
         env:
@@ -69,6 +84,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+# Required pre-merge gate for #43: every PR into main, and every push to
+# main (post-merge signal), runs fmt/clippy/test/docs against the pinned
+# toolchain in rust-toolchain.toml, plus a build+import smoke test for the
+# Python bindings. See docs/sdlc-process-notes.md for why fmt/docs are
+# gated with warnings-as-errors from the start rather than added loose and
+# tightened later.
+#
+# Slow/optional suites (cargo-deny, the Scala Spark adapter, benchmark
+# regressions) live in nightly.yml instead, so this file stays fast enough
+# to be a required check on every PR.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test (workspace)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace --all-targets
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps --workspace
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
+  python:
+    name: python bindings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install "maturin>=1.7,<2" pyarrow
+      # No pytest suite exists yet for bindings/cubism-py (tracked under
+      # #43's remaining workstreams) — this is a build + import smoke test,
+      # not a claim that the bindings have behavioral test coverage.
+      - name: maturin build
+        working-directory: bindings/cubism-py
+        run: maturin build --out dist
+      - run: pip install --no-index --find-links bindings/cubism-py/dist cubism
+      - run: python -c "import cubism; print(cubism.__file__)"
+
+  # Single required status check for branch protection, so the protected-
+  # branch rule doesn't need updating every time a job above is added,
+  # renamed, or split.
+  ci-required:
+    name: CI required checks
+    if: always()
+    needs: [fmt, clippy, test, docs, python]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs succeeded
+        run: |
+          for result in ${{ join(needs.*.result, ' ') }}; do
+            if [ "$result" != "success" ]; then
+              echo "at least one required job did not succeed: ${{ join(needs.*.result, ', ') }}"
+              exit 1
+            fi
+          done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Keep in sync with ci.yml's RUST_TOOLCHAIN and rust-toolchain.toml.
+  RUST_TOOLCHAIN: "1.96.1"
 
 jobs:
   cargo-deny:
@@ -32,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       # Runs the #[ignore]'d 1M-row golden-digest case that ci.yml skips to
       # stay fast. Not a perf-regression *comparison* yet (no baseline

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,56 @@
+name: Nightly
+
+# The slow/optional half of #43's gate: dependency & license scanning, the
+# Scala Spark adapter (not a Cargo workspace member — see spark-adapter/),
+# and a benchmark-regression smoke test. None of these are required PR
+# checks (ci.yml is), so a red run here doesn't block a merge — it's a
+# signal for whoever is on the #43 rotation to triage, per the remediation
+# policy in deny.toml.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (advisories, licenses, bans, sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
+  bench-smoke:
+    name: benchmark regression smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      # Runs the #[ignore]'d 1M-row golden-digest case that ci.yml skips to
+      # stay fast. Not a perf-regression *comparison* yet (no baseline
+      # storage/threshold) — that's still open under #43's "publish deeper
+      # benchmarks on a schedule" workstream; today this only proves the
+      # 1M-row path still runs and its digest still matches.
+      - run: cargo test -p cubism-timeseries-bench --lib -- --ignored golden_digest_sparse_1m
+
+  spark-adapter:
+    name: spark-adapter (sbt)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: sbt/setup-sbt@v1
+      - uses: coursier/cache-action@v6
+      - working-directory: spark-adapter
+        run: sbt test

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ vectorized group accumulators, the CLI, and the Python bindings. Not yet:
 quantiles, published packages (crates.io / PyPI), streaming ingestion.
 
 ```
-cargo test          # 75 tests incl. property tests + legacy parity fixtures
+cargo test          # 250 tests incl. property tests + legacy parity fixtures
 cargo run -p cubism-cli -- validate examples/web_events.yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,28 @@ cargo test          # 75 tests incl. property tests + legacy parity fixtures
 cargo run -p cubism-cli -- validate examples/web_events.yaml
 ```
 
+## Development
+
+`rust-toolchain.toml` pins the toolchain `cargo`/`rustup` use automatically.
+Required PR checks (`.github/workflows/ci.yml`) reproduce locally as:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+cd bindings/cubism-py && maturin build --out dist   # python bindings build smoke
+```
+
+Nightly-only checks (`.github/workflows/nightly.yml`, not required for
+merge — see `deny.toml` for the license/advisory remediation policy):
+
+```bash
+cargo deny check                                                # licenses/advisories/bans/sources
+cargo test -p cubism-timeseries-bench --lib -- --ignored golden_digest_sparse_1m
+cd spark-adapter && sbt test                                     # optional Scala adapter, see #43
+```
+
 ## License
 
 Apache-2.0

--- a/bindings/cubism-py/src/lib.rs
+++ b/bindings/cubism-py/src/lib.rs
@@ -12,9 +12,9 @@
 //! output: `xunit`, measures, and `*__sketch` blob columns).
 
 use arrow::pyarrow::ToPyArrow;
+use cubism_core::CubeSpec;
 use cubism_core::sketch::kmv::DEFAULT_SKETCH_SIZE;
 use cubism_core::sketch::{ExemplarSample, KmvSketch, TopK};
-use cubism_core::CubeSpec;
 use cubism_datafusion::datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -47,7 +47,8 @@ fn build_cube(py: Python<'_>, spec_yaml: &str, input_path: &str) -> PyResult<Py<
             runtime.block_on(async {
                 let ctx = SessionContext::new();
                 if input_path.ends_with(".csv") {
-                    ctx.register_csv("events", input_path, CsvReadOptions::new()).await?;
+                    ctx.register_csv("events", input_path, CsvReadOptions::new())
+                        .await?;
                 } else {
                     ctx.register_parquet("events", input_path, ParquetReadOptions::default())
                         .await?;
@@ -86,13 +87,17 @@ impl PyKmvSketch {
     #[new]
     #[pyo3(signature = (k = DEFAULT_SKETCH_SIZE))]
     fn new(k: u32) -> Self {
-        PyKmvSketch { inner: KmvSketch::new(k) }
+        PyKmvSketch {
+            inner: KmvSketch::new(k),
+        }
     }
 
     /// Deserialize a sketch blob (a `*__sketch` cube column value).
     #[staticmethod]
     fn from_bytes(data: &[u8]) -> PyResult<Self> {
-        Ok(PyKmvSketch { inner: KmvSketch::from_bytes(data).map_err(value_err)? })
+        Ok(PyKmvSketch {
+            inner: KmvSketch::from_bytes(data).map_err(value_err)?,
+        })
     }
 
     fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
@@ -101,7 +106,9 @@ impl PyKmvSketch {
 
     /// Union merge (associative + commutative).
     fn merge(&self, other: &PyKmvSketch) -> PyKmvSketch {
-        PyKmvSketch { inner: self.inner.merge(&other.inner) }
+        PyKmvSketch {
+            inner: self.inner.merge(&other.inner),
+        }
     }
 
     /// Estimated distinct count (exact while under-full).
@@ -128,7 +135,11 @@ impl PyKmvSketch {
     }
 
     fn __repr__(&self) -> String {
-        format!("KmvSketch(k={}, estimate={:.1})", self.inner.k(), self.inner.estimate())
+        format!(
+            "KmvSketch(k={}, estimate={:.1})",
+            self.inner.k(),
+            self.inner.estimate()
+        )
     }
 }
 

--- a/crates/cubism-cli/src/main.rs
+++ b/crates/cubism-cli/src/main.rs
@@ -41,15 +41,17 @@
 //! `docs/TIMESERIES_PHASE_3_HANDOFF.md` for how the non-durable default was
 //! discovered to be a hard limitation, not just a production gap.
 
+use cubism_core::temporal::{WindowId, WindowRevision};
 use cubism_core::{CubeSpec, EventTime, TimeRange};
 use cubism_datafusion::build_cube;
 use cubism_datafusion::datafusion::dataframe::DataFrameWriteOptions;
 use cubism_datafusion::datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
 use cubism_datafusion::temporal_build::{
-    explain_temporal_build, temporal_state_schema, write_temporal_fixtures, NullEventTimePolicy,
+    NullEventTimePolicy, explain_temporal_build, temporal_state_schema, write_temporal_fixtures,
 };
-use cubism_core::temporal::{WindowId, WindowRevision};
-use cubism_iceberg::{AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, PublicationStore, TemporalTable};
+use cubism_iceberg::{
+    AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, PublicationStore, TemporalTable,
+};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
@@ -73,19 +75,28 @@ fn validate(path: &str) -> Result<(), String> {
     Ok(())
 }
 
-async fn run(spec_path: &str, input: &str, output: Option<&str>, show: usize) -> Result<(), String> {
+async fn run(
+    spec_path: &str,
+    input: &str,
+    output: Option<&str>,
+    show: usize,
+) -> Result<(), String> {
     let spec = load_spec(spec_path)?;
     let ctx = SessionContext::new();
 
     let started = Instant::now();
     if input.ends_with(".csv") {
-        ctx.register_csv("events", input, CsvReadOptions::new()).await
+        ctx.register_csv("events", input, CsvReadOptions::new())
+            .await
     } else {
-        ctx.register_parquet("events", input, ParquetReadOptions::default()).await
+        ctx.register_parquet("events", input, ParquetReadOptions::default())
+            .await
     }
     .map_err(|e| format!("cannot read {input}: {e}"))?;
 
-    let (df, dict) = build_cube(&ctx, &spec, "events").await.map_err(|e| e.to_string())?;
+    let (df, dict) = build_cube(&ctx, &spec, "events")
+        .await
+        .map_err(|e| e.to_string())?;
 
     let cube = df.cache().await.map_err(|e| e.to_string())?;
     let cells = cube.clone().count().await.map_err(|e| e.to_string())?;
@@ -110,8 +121,10 @@ async fn run(spec_path: &str, input: &str, output: Option<&str>, show: usize) ->
         cube.clone()
             .select_columns(&display_cols)
             .and_then(|d| {
-                d.sort(vec![cubism_datafusion::datafusion::prelude::col(&spec.measures[0].name)
-                    .sort(false, false)])
+                d.sort(vec![
+                    cubism_datafusion::datafusion::prelude::col(&spec.measures[0].name)
+                        .sort(false, false),
+                ])
             })
             .and_then(|d| d.limit(0, Some(show)))
             .map_err(|e| e.to_string())?
@@ -149,7 +162,11 @@ async fn temporal_build(
     let null_policy = match null_policy {
         "reject" => NullEventTimePolicy::Reject,
         "quarantine" => NullEventTimePolicy::Quarantine,
-        other => return Err(format!("--null-policy expects 'reject' or 'quarantine', got '{other}'")),
+        other => {
+            return Err(format!(
+                "--null-policy expects 'reject' or 'quarantine', got '{other}'"
+            ));
+        }
     };
     let window = match window {
         Some((start, end)) => {
@@ -163,9 +180,11 @@ async fn temporal_build(
     let ctx = SessionContext::new();
     let started = Instant::now();
     if input.ends_with(".csv") {
-        ctx.register_csv("events", input, CsvReadOptions::new()).await
+        ctx.register_csv("events", input, CsvReadOptions::new())
+            .await
     } else {
-        ctx.register_parquet("events", input, ParquetReadOptions::default()).await
+        ctx.register_parquet("events", input, ParquetReadOptions::default())
+            .await
     }
     .map_err(|e| format!("cannot read {input}: {e}"))?;
 
@@ -196,9 +215,10 @@ async fn temporal_build(
         }
     };
 
-    let output = cubism_datafusion::build_temporal(&ctx, &spec, "events", window, None, null_policy)
-        .await
-        .map_err(|e| e.to_string())?;
+    let output =
+        cubism_datafusion::build_temporal(&ctx, &spec, "events", window, None, null_policy)
+            .await
+            .map_err(|e| e.to_string())?;
     write_temporal_fixtures(&output, states_path, registry_path)
         .await
         .map_err(|e| e.to_string())?;
@@ -276,17 +296,26 @@ async fn iceberg_build(
 
     let states_schema = temporal_state_schema(&spec).map_err(|e| e.to_string())?;
     let config = if durable {
-        CatalogConfig::Sqlite { warehouse: PathBuf::from(warehouse), catalog_db: PathBuf::from(catalog_db) }
+        CatalogConfig::Sqlite {
+            warehouse: PathBuf::from(warehouse),
+            catalog_db: PathBuf::from(catalog_db),
+        }
     } else {
-        CatalogConfig::Memory { warehouse: PathBuf::from(warehouse) }
+        CatalogConfig::Memory {
+            warehouse: PathBuf::from(warehouse),
+        }
     };
-    let catalog = cubism_iceberg::config::open_catalog(&config).await.map_err(|e| e.to_string())?;
+    let catalog = cubism_iceberg::config::open_catalog(&config)
+        .await
+        .map_err(|e| e.to_string())?;
     let table = TemporalTable::create(catalog.as_ref(), &spec.name, &states_schema)
         .await
         .map_err(|e| e.to_string())?;
 
     let publications = if durable {
-        PublicationStore::sqlite(std::path::Path::new(control_db)).await.map_err(|e| e.to_string())?
+        PublicationStore::sqlite(std::path::Path::new(control_db))
+            .await
+            .map_err(|e| e.to_string())?
     } else {
         PublicationStore::in_memory()
     };
@@ -368,9 +397,14 @@ async fn iceberg_build(
         }
     };
 
-    let expected_current =
-        publications.current(&spec.name, &window_id).await.map_err(|e| e.to_string())?;
-    let publication = publications.publish(run_id, expected_current).await.map_err(|e| e.to_string())?;
+    let expected_current = publications
+        .current(&spec.name, &window_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    let publication = publications
+        .publish(run_id, expected_current)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let visible = AggregateReader::read_window(catalog.as_ref(), &table, &publications, &window_id)
         .await
@@ -389,7 +423,9 @@ async fn iceberg_build(
         result.row_count,
     );
     if durable {
-        println!("catalog and control store are durable (--catalog-db, --control-db) — a second invocation with the same paths observes this one's tables and publications");
+        println!(
+            "catalog and control store are durable (--catalog-db, --control-db) — a second invocation with the same paths observes this one's tables and publications"
+        );
     } else {
         println!(
             "note: this build used the non-durable defaults — catalog and control store do not survive past this process (pass --catalog-db and --control-db for a durable build; see docs/TIMESERIES_PHASE_4_HANDOFF.md)"
@@ -414,30 +450,44 @@ async fn serve(
 ) -> Result<(), String> {
     let store = cubism_serve::CubeStore::from_path(cube_path).map_err(|e| e.to_string())?;
     match (spec_path, warehouse) {
-        (None, None) => cubism_serve::serve(store, port).await.map_err(|e| e.to_string()),
+        (None, None) => cubism_serve::serve(store, port)
+            .await
+            .map_err(|e| e.to_string()),
         (Some(spec_path), Some(warehouse)) => {
             let spec = load_spec(spec_path)?;
             let durable = catalog_db.is_some() || control_db.is_some();
             let (catalog_db, control_db) = match (catalog_db, control_db) {
                 (Some(c), Some(p)) => (c, p),
                 _ if durable => {
-                    return Err("--catalog-db and --control-db must both be given, or neither".into());
+                    return Err(
+                        "--catalog-db and --control-db must both be given, or neither".into(),
+                    );
                 }
                 _ => ("", ""),
             };
             let config = if durable {
-                CatalogConfig::Sqlite { warehouse: PathBuf::from(warehouse), catalog_db: PathBuf::from(catalog_db) }
+                CatalogConfig::Sqlite {
+                    warehouse: PathBuf::from(warehouse),
+                    catalog_db: PathBuf::from(catalog_db),
+                }
             } else {
-                CatalogConfig::Memory { warehouse: PathBuf::from(warehouse) }
+                CatalogConfig::Memory {
+                    warehouse: PathBuf::from(warehouse),
+                }
             };
             let publications = if durable {
-                PublicationStore::sqlite(std::path::Path::new(control_db)).await.map_err(|e| e.to_string())?
+                PublicationStore::sqlite(std::path::Path::new(control_db))
+                    .await
+                    .map_err(|e| e.to_string())?
             } else {
                 PublicationStore::in_memory()
             };
-            let series =
-                cubism_serve::SeriesState::open(spec, &config, publications).await.map_err(|e| e.to_string())?;
-            cubism_serve::serve_with_series(store, series, port).await.map_err(|e| e.to_string())
+            let series = cubism_serve::SeriesState::open(spec, &config, publications)
+                .await
+                .map_err(|e| e.to_string())?;
+            cubism_serve::serve_with_series(store, series, port)
+                .await
+                .map_err(|e| e.to_string())
         }
         _ => Err("--spec and --warehouse must be given together, or neither".into()),
     }
@@ -593,7 +643,10 @@ async fn main() -> ExitCode {
                     ("--window-id", Some(v)) => window_id = Some(v.clone()),
                     ("--revision", Some(v)) => match v.parse() {
                         Ok(n) => revision = Some(n),
-                        Err(_) => flag_err = Some(format!("--revision expects a positive integer, got '{v}'")),
+                        Err(_) => {
+                            flag_err =
+                                Some(format!("--revision expects a positive integer, got '{v}'"))
+                        }
                     },
                     ("--run-id", Some(v)) => run_id = Some(v.clone()),
                     ("--warehouse", Some(v)) => warehouse = Some(v.clone()),

--- a/crates/cubism-core/src/aggregate_state.rs
+++ b/crates/cubism-core/src/aggregate_state.rs
@@ -784,8 +784,7 @@ mod tests {
     ///
     /// [issue #9]: https://github.com/jeromebanks/cubism-rs/issues/9
     const GOLDEN_AVERAGE_V1: &str = "41564701000000000000f83f0100000000000000";
-    const GOLDEN_VARIANCE_V1: &str =
-        "56415201010000000000000000000000000000400000000000000000";
+    const GOLDEN_VARIANCE_V1: &str = "56415201010000000000000000000000000000400000000000000000";
 
     /// Both vectors below were cross-checked against Python's
     /// `zlib.crc32` over the same body bytes, so they are pinned by an
@@ -796,7 +795,10 @@ mod tests {
         let mut average = AverageState::new();
         average.accumulate(1.5).unwrap();
         // V1 body, version byte bumped to 02, plus the trailing CRC32.
-        assert_eq!(hex(&average.encode()), "41564702000000000000f83f0100000000000000dff5fa2d");
+        assert_eq!(
+            hex(&average.encode()),
+            "41564702000000000000f83f0100000000000000dff5fa2d"
+        );
 
         let mut variance = VarianceState::new();
         variance.accumulate(2.0).unwrap();

--- a/crates/cubism-core/src/lattice.rs
+++ b/crates/cubism-core/src/lattice.rs
@@ -36,8 +36,10 @@ pub fn generate_xunits(
         if dim_ypaths.is_empty() {
             continue;
         }
-        let mut new_units: Vec<XUnit> =
-            dim_ypaths.iter().map(|yp| XUnit::new(vec![yp.clone()])).collect();
+        let mut new_units: Vec<XUnit> = dim_ypaths
+            .iter()
+            .map(|yp| XUnit::new(vec![yp.clone()]))
+            .collect();
         for existing in &candidates {
             if bound.is_some_and(|b| existing.num_dimensions() >= b) {
                 continue; // MaxDimensions is monotone: extensions can never re-qualify.
@@ -70,7 +72,9 @@ pub fn generate_xunits_unpruned(per_dimension: &[Vec<YPath>]) -> Vec<XUnit> {
             .iter()
             .map(|yp| XUnit::new(vec![yp.clone()]))
             .chain(candidates.iter().flat_map(|existing| {
-                dim_ypaths.iter().map(|yp| existing.clone().with_ypath(yp.clone()))
+                dim_ypaths
+                    .iter()
+                    .map(|yp| existing.clone().with_ypath(yp.clone()))
             }))
             .collect();
         candidates.extend(new_units);
@@ -123,7 +127,10 @@ mod tests {
         // Legacy ThreeDimRule ("xunit.ypaths.size == 3") over the same
         // fixture yields 4 XUnits: 2 platform levels × 2 geo levels × 1 gender.
         let rules = vec![FilterRule::And {
-            rules: vec![FilterRule::MinDimensions { n: 3 }, FilterRule::MaxDimensions { n: 3 }],
+            rules: vec![
+                FilterRule::MinDimensions { n: 3 },
+                FilterRule::MaxDimensions { n: 3 },
+            ],
         }];
         let x = generate_xunits(&test_dims(), &rules, false);
         assert_eq!(x.len(), 4);
@@ -149,7 +156,9 @@ mod tests {
     fn pruned_equals_filtered_unpruned() {
         let rules = vec![
             FilterRule::MaxDimensions { n: 2 },
-            FilterRule::NotTogether { dims: vec!["geo".into(), "platform".into()] },
+            FilterRule::NotTogether {
+                dims: vec!["geo".into(), "platform".into()],
+            },
         ];
         let pruned = generate_xunits(&test_dims(), &rules, false);
         let reference: Vec<XUnit> = generate_xunits_unpruned(&test_dims())

--- a/crates/cubism-core/src/rules.rs
+++ b/crates/cubism-core/src/rules.rs
@@ -17,27 +17,51 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FilterRule {
     /// Include XUnits with at most `n` dimensions.
-    MaxDimensions { n: usize },
+    MaxDimensions {
+        n: usize,
+    },
     /// Include XUnits with at least `n` dimensions.
-    MinDimensions { n: usize },
+    MinDimensions {
+        n: usize,
+    },
     /// Include only XUnits containing this dimension.
-    ContainsDim { dim: String },
+    ContainsDim {
+        dim: String,
+    },
     /// Include only XUnits containing all of these dimensions.
-    ContainsAllDims { dims: Vec<String> },
+    ContainsAllDims {
+        dims: Vec<String>,
+    },
     /// Include this dimension only as a single-dimension (top-level) XUnit.
-    TopLevel { dim: String },
+    TopLevel {
+        dim: String,
+    },
     /// Exclude XUnits containing all of these dimensions together.
-    NotTogether { dims: Vec<String> },
+    NotTogether {
+        dims: Vec<String>,
+    },
     /// Exclude XUnits combining `dim` with a YPath for `other_dim` that has
     /// drilled down to attribute `attr`.
-    NotWithAttribute { dim: String, other_dim: String, attr: String },
+    NotWithAttribute {
+        dim: String,
+        other_dim: String,
+        attr: String,
+    },
     /// Exclude this dimension as a standalone single-dimension XUnit.
-    NotAlone { dim: String },
+    NotAlone {
+        dim: String,
+    },
     /// Include only XUnits containing this dimension (alias kept for spec
     /// readability; same predicate as `ContainsDim`).
-    OnlyWith { dim: String },
-    And { rules: Vec<FilterRule> },
-    Or { rules: Vec<FilterRule> },
+    OnlyWith {
+        dim: String,
+    },
+    And {
+        rules: Vec<FilterRule>,
+    },
+    Or {
+        rules: Vec<FilterRule>,
+    },
 }
 
 impl FilterRule {
@@ -52,10 +76,12 @@ impl FilterRule {
             FilterRule::TopLevel { dim } => {
                 xunit.num_dimensions() == 1 && xunit.contains_dimension(dim)
             }
-            FilterRule::NotTogether { dims } => {
-                !dims.iter().all(|d| xunit.contains_dimension(d))
-            }
-            FilterRule::NotWithAttribute { dim, other_dim, attr } => {
+            FilterRule::NotTogether { dims } => !dims.iter().all(|d| xunit.contains_dimension(d)),
+            FilterRule::NotWithAttribute {
+                dim,
+                other_dim,
+                attr,
+            } => {
                 if xunit.contains_dimension(dim) {
                     match xunit.for_dimension(other_dim) {
                         Some(yp) => !yp.attributes.iter().any(|(name, _)| name == attr),
@@ -121,7 +147,11 @@ mod tests {
     use crate::ypath::YPath;
 
     fn xu(dims: &[&str]) -> XUnit {
-        XUnit::new(dims.iter().map(|d| YPath::new(*d).with_attribute(*d, "v")).collect())
+        XUnit::new(
+            dims.iter()
+                .map(|d| YPath::new(*d).with_attribute(*d, "v"))
+                .collect(),
+        )
     }
 
     #[test]
@@ -138,7 +168,9 @@ mod tests {
 
     #[test]
     fn not_together() {
-        let rule = FilterRule::NotTogether { dims: vec!["a".into(), "b".into()] };
+        let rule = FilterRule::NotTogether {
+            dims: vec!["a".into(), "b".into()],
+        };
         assert!(!rule.should_include(&xu(&["a", "b", "c"])));
         assert!(rule.should_include(&xu(&["a", "c"])));
         assert!(rule.should_include(&xu(&["b"])));
@@ -147,7 +179,9 @@ mod tests {
     #[test]
     fn contains_all_dims_actually_checks_the_xunit() {
         // The legacy implementation was `dims.forall(dims.contains)` — always true.
-        let rule = FilterRule::ContainsAllDims { dims: vec!["a".into(), "b".into()] };
+        let rule = FilterRule::ContainsAllDims {
+            dims: vec!["a".into(), "b".into()],
+        };
         assert!(rule.should_include(&xu(&["a", "b", "c"])));
         assert!(!rule.should_include(&xu(&["a", "c"])));
     }
@@ -173,7 +207,9 @@ mod tests {
             attr: "city".into(),
         };
         let deep = XUnit::new(vec![
-            YPath::new("geo").with_attribute("country", "CZ").with_attribute("city", "Prague"),
+            YPath::new("geo")
+                .with_attribute("country", "CZ")
+                .with_attribute("city", "Prague"),
             YPath::new("gender").with_attribute("gender", "F"),
         ]);
         let shallow = XUnit::new(vec![
@@ -187,7 +223,10 @@ mod tests {
     #[test]
     fn and_or_combinators() {
         let exactly2 = FilterRule::And {
-            rules: vec![FilterRule::MaxDimensions { n: 2 }, FilterRule::MinDimensions { n: 2 }],
+            rules: vec![
+                FilterRule::MaxDimensions { n: 2 },
+                FilterRule::MinDimensions { n: 2 },
+            ],
         };
         assert!(exactly2.should_include(&xu(&["a", "b"])));
         assert!(!exactly2.should_include(&xu(&["a"])));
@@ -214,8 +253,12 @@ mod tests {
         assert_eq!(
             max_dimensions_bound(&[
                 FilterRule::MaxDimensions { n: 3 },
-                FilterRule::And { rules: vec![FilterRule::MaxDimensions { n: 2 }] },
-                FilterRule::Or { rules: vec![FilterRule::MaxDimensions { n: 1 }] },
+                FilterRule::And {
+                    rules: vec![FilterRule::MaxDimensions { n: 2 }]
+                },
+                FilterRule::Or {
+                    rules: vec![FilterRule::MaxDimensions { n: 1 }]
+                },
             ]),
             Some(2)
         );

--- a/crates/cubism-core/src/sketch/centroid.rs
+++ b/crates/cubism-core/src/sketch/centroid.rs
@@ -27,7 +27,10 @@ impl Default for Centroid {
 
 impl Centroid {
     pub fn new() -> Self {
-        Centroid { count: 0, sums: Vec::new() }
+        Centroid {
+            count: 0,
+            sums: Vec::new(),
+        }
     }
 
     pub fn count(&self) -> u64 {
@@ -78,7 +81,12 @@ impl Centroid {
         }
         Ok(Centroid {
             count: self.count + other.count,
-            sums: self.sums.iter().zip(&other.sums).map(|(a, b)| a + b).collect(),
+            sums: self
+                .sums
+                .iter()
+                .zip(&other.sums)
+                .map(|(a, b)| a + b)
+                .collect(),
         })
     }
 

--- a/crates/cubism-core/src/sketch/kmv.rs
+++ b/crates/cubism-core/src/sketch/kmv.rs
@@ -42,7 +42,10 @@ pub struct KmvSketch {
 impl KmvSketch {
     pub fn new(k: u32) -> Self {
         assert!(k >= 8, "sketch size k must be at least 8");
-        KmvSketch { k, hashes: Vec::new() }
+        KmvSketch {
+            k,
+            hashes: Vec::new(),
+        }
     }
 
     pub fn k(&self) -> u32 {
@@ -115,7 +118,10 @@ impl KmvSketch {
                 (None, None) => break,
             }
         }
-        KmvSketch { k: k as u32, hashes: merged }
+        KmvSketch {
+            k: k as u32,
+            hashes: merged,
+        }
     }
 
     /// Estimated distinct count. Exact while the sketch is under-full.
@@ -143,7 +149,11 @@ impl KmvSketch {
     /// Estimated Jaccard similarity |A∩B| / |A∪B|.
     pub fn jaccard(&self, other: &KmvSketch) -> f64 {
         let union = self.union_estimate(other);
-        if union == 0.0 { 0.0 } else { self.intersection_estimate(other) / union }
+        if union == 0.0 {
+            0.0
+        } else {
+            self.intersection_estimate(other) / union
+        }
     }
 
     /// Serialize as format v1: `"KMV" ver:u8 k:u32-le n:u32-le hash:u64-le*n`.
@@ -162,7 +172,10 @@ impl KmvSketch {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CubismError> {
         let err = |reason: String| CubismError::Decode(format!("KMV sketch: {reason}"));
         if bytes.len() < HEADER_LEN {
-            return Err(err(format!("{} bytes is shorter than the header", bytes.len())));
+            return Err(err(format!(
+                "{} bytes is shorter than the header",
+                bytes.len()
+            )));
         }
         if &bytes[0..3] != MAGIC {
             return Err(err("bad magic".into()));
@@ -173,7 +186,11 @@ impl KmvSketch {
         let k = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
         let n = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
         if bytes.len() != HEADER_LEN + n * 8 {
-            return Err(err(format!("expected {} bytes for n={n}, got {}", HEADER_LEN + n * 8, bytes.len())));
+            return Err(err(format!(
+                "expected {} bytes for n={n}, got {}",
+                HEADER_LEN + n * 8,
+                bytes.len()
+            )));
         }
         if n > k as usize {
             return Err(err(format!("n={n} exceeds k={k}")));
@@ -221,7 +238,10 @@ mod tests {
         let s = sketch_of(1024, (0..n).map(|i| format!("user_{i}")));
         let est = s.estimate();
         let rel_err = (est - n as f64).abs() / n as f64;
-        assert!(rel_err < 0.125, "estimate {est} vs {n}: rel err {rel_err:.4}");
+        assert!(
+            rel_err < 0.125,
+            "estimate {est} vs {n}: rel err {rel_err:.4}"
+        );
     }
 
     #[test]

--- a/crates/cubism-core/src/sketch/sample.rs
+++ b/crates/cubism-core/src/sketch/sample.rs
@@ -27,7 +27,10 @@ pub struct ExemplarSample {
 impl ExemplarSample {
     pub fn new(capacity: u32) -> Self {
         assert!(capacity >= 1, "sample capacity must be at least 1");
-        ExemplarSample { capacity, entries: Vec::new() }
+        ExemplarSample {
+            capacity,
+            entries: Vec::new(),
+        }
     }
 
     pub fn capacity(&self) -> u32 {
@@ -85,7 +88,10 @@ impl ExemplarSample {
                 (None, None) => break,
             }
         }
-        ExemplarSample { capacity, entries: merged }
+        ExemplarSample {
+            capacity,
+            entries: merged,
+        }
     }
 
     /// The sampled values (hash order — effectively random order).
@@ -96,7 +102,9 @@ impl ExemplarSample {
     /// Present as a JSON array of the sampled values.
     pub fn to_json(&self) -> String {
         serde_json::Value::Array(
-            self.values().map(|v| serde_json::Value::String(v.to_string())).collect(),
+            self.values()
+                .map(|v| serde_json::Value::String(v.to_string()))
+                .collect(),
         )
         .to_string()
     }
@@ -139,17 +147,15 @@ impl ExemplarSample {
             if cursor.len() < 10 + len {
                 return Err(err("truncated value"));
             }
-            let value = std::str::from_utf8(&cursor[10..10 + len])
-                .map_err(|_| err("value is not utf8"))?;
+            let value =
+                std::str::from_utf8(&cursor[10..10 + len]).map_err(|_| err("value is not utf8"))?;
             entries.push((hash, value.to_string()));
             cursor = &cursor[10 + len..];
         }
         if !cursor.is_empty() {
             return Err(err("trailing bytes"));
         }
-        if !entries.is_sorted_by_key(|(h, _)| *h)
-            || entries.windows(2).any(|w| w[0].0 == w[1].0)
-        {
+        if !entries.is_sorted_by_key(|(h, _)| *h) || entries.windows(2).any(|w| w[0].0 == w[1].0) {
             return Err(err("entries are not sorted-distinct by hash"));
         }
         Ok(ExemplarSample { capacity, entries })

--- a/crates/cubism-core/src/sketch/topk.rs
+++ b/crates/cubism-core/src/sketch/topk.rs
@@ -32,7 +32,10 @@ pub struct TopK {
 impl TopK {
     pub fn new(capacity: u32) -> Self {
         assert!(capacity >= 1, "top-k capacity must be at least 1");
-        TopK { capacity, entries: HashMap::new() }
+        TopK {
+            capacity,
+            entries: HashMap::new(),
+        }
     }
 
     pub fn capacity(&self) -> u32 {
@@ -89,8 +92,7 @@ impl TopK {
     /// All tracked entries, best-first (score desc, key asc as tiebreak —
     /// the deterministic order used everywhere, including serialization).
     fn ranked(&self) -> Vec<(String, f64)> {
-        let mut v: Vec<(String, f64)> =
-            self.entries.iter().map(|(k, s)| (k.clone(), *s)).collect();
+        let mut v: Vec<(String, f64)> = self.entries.iter().map(|(k, s)| (k.clone(), *s)).collect();
         v.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         v
     }
@@ -151,8 +153,8 @@ impl TopK {
             if cursor.len() < 10 + len {
                 return Err(err("truncated key"));
             }
-            let key = std::str::from_utf8(&cursor[10..10 + len])
-                .map_err(|_| err("key is not utf8"))?;
+            let key =
+                std::str::from_utf8(&cursor[10..10 + len]).map_err(|_| err("key is not utf8"))?;
             entries.insert(key.to_string(), score);
             cursor = &cursor[10 + len..];
         }

--- a/crates/cubism-core/src/temporal.rs
+++ b/crates/cubism-core/src/temporal.rs
@@ -754,11 +754,17 @@ mod tests {
         let bucket_end = BucketEnd::from_unix_micros(0);
 
         assert_eq!(
-            policy.classify(EventTime::from_unix_micros(10 * MICROS_PER_SECOND - 1), bucket_end),
+            policy.classify(
+                EventTime::from_unix_micros(10 * MICROS_PER_SECOND - 1),
+                bucket_end
+            ),
             Lateness::OnTime
         );
         assert_eq!(
-            policy.classify(EventTime::from_unix_micros(10 * MICROS_PER_SECOND), bucket_end),
+            policy.classify(
+                EventTime::from_unix_micros(10 * MICROS_PER_SECOND),
+                bucket_end
+            ),
             Lateness::Late
         );
     }

--- a/crates/cubism-core/src/ypath.rs
+++ b/crates/cubism-core/src/ypath.rs
@@ -26,7 +26,10 @@ pub struct YPath {
 
 impl YPath {
     pub fn new(dim: impl Into<String>) -> Self {
-        YPath { dim: dim.into(), attributes: Vec::new() }
+        YPath {
+            dim: dim.into(),
+            attributes: Vec::new(),
+        }
     }
 
     pub fn with_attribute(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
@@ -113,7 +116,14 @@ impl XUnit {
     }
 
     pub fn without_dimension(&self, dim: &str) -> XUnit {
-        XUnit { ypaths: self.ypaths.iter().filter(|yp| yp.dim != dim).cloned().collect() }
+        XUnit {
+            ypaths: self
+                .ypaths
+                .iter()
+                .filter(|yp| yp.dim != dim)
+                .cloned()
+                .collect(),
+        }
     }
 }
 
@@ -144,13 +154,19 @@ impl FromStr for XUnit {
             return Ok(XUnit::global());
         }
         if s.is_empty() {
-            return Err(CubismError::XUnitParse { input: s.into(), reason: "empty string".into() });
+            return Err(CubismError::XUnitParse {
+                input: s.into(),
+                reason: "empty string".into(),
+            });
         }
         let ypaths = s
             .split(',')
             .map(parse_ypath)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CubismError::XUnitParse { input: s.into(), reason: e.to_string() })?;
+            .map_err(|e| CubismError::XUnitParse {
+                input: s.into(),
+                reason: e.to_string(),
+            })?;
         Ok(XUnit { ypaths })
     }
 }
@@ -162,20 +178,34 @@ impl FromStr for XUnit {
 /// sentinel sequence (`___`, `###`, `+++`) — spec validation should reject
 /// such dimension values at ingest when exactness matters.
 pub fn scrub_value(dirty: &str) -> String {
-    dirty.replace('/', "___").replace('=', "###").replace(',', "+++")
+    dirty
+        .replace('/', "___")
+        .replace('=', "###")
+        .replace(',', "+++")
 }
 
 /// Inverse of [`scrub_value`].
 pub fn unscrub_value(scrubbed: &str) -> String {
-    scrubbed.replace("___", "/").replace("###", "=").replace("+++", ",")
+    scrubbed
+        .replace("___", "/")
+        .replace("###", "=")
+        .replace("+++", ",")
 }
 
 fn parse_ypath(s: &str) -> Result<YPath, CubismError> {
-    let err = |reason: &str| CubismError::YPathParse { input: s.into(), reason: reason.into() };
+    let err = |reason: &str| CubismError::YPathParse {
+        input: s.into(),
+        reason: reason.into(),
+    };
 
-    let rest = s.strip_prefix('/').ok_or_else(|| err("must start with '/'"))?;
+    let rest = s
+        .strip_prefix('/')
+        .ok_or_else(|| err("must start with '/'"))?;
     let mut segments = rest.split('/');
-    let dim = segments.next().filter(|d| !d.is_empty()).ok_or_else(|| err("missing dimension name"))?;
+    let dim = segments
+        .next()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| err("missing dimension name"))?;
 
     let attributes = segments
         .map(|seg| {
@@ -189,7 +219,10 @@ fn parse_ypath(s: &str) -> Result<YPath, CubismError> {
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(YPath { dim: dim.to_string(), attributes })
+    Ok(YPath {
+        dim: dim.to_string(),
+        attributes,
+    })
 }
 
 #[cfg(test)]
@@ -197,7 +230,9 @@ mod tests {
     use super::*;
 
     fn geo() -> YPath {
-        YPath::new("geo").with_attribute("country", "CZ").with_attribute("city", "Prague")
+        YPath::new("geo")
+            .with_attribute("country", "CZ")
+            .with_attribute("city", "Prague")
     }
 
     #[test]
@@ -224,10 +259,19 @@ mod tests {
 
     #[test]
     fn xunit_display_is_normalized() {
-        let x = XUnit::new(vec![geo(), YPath::new("gender").with_attribute("gender", "F")]);
-        let y = XUnit::new(vec![YPath::new("gender").with_attribute("gender", "F"), geo()]);
+        let x = XUnit::new(vec![
+            geo(),
+            YPath::new("gender").with_attribute("gender", "F"),
+        ]);
+        let y = XUnit::new(vec![
+            YPath::new("gender").with_attribute("gender", "F"),
+            geo(),
+        ]);
         assert_eq!(x.to_string(), y.to_string());
-        assert_eq!(x.to_string(), "/gender/gender=F,/geo/country=CZ/city=Prague");
+        assert_eq!(
+            x.to_string(),
+            "/gender/gender=F,/geo/country=CZ/city=Prague"
+        );
     }
 
     #[test]
@@ -241,7 +285,10 @@ mod tests {
         let s = "/gender/gender=F,/geo/country=CZ/city=Prague";
         let x: XUnit = s.parse().unwrap();
         assert_eq!(x.num_dimensions(), 2);
-        assert_eq!(x.for_dimension("geo").unwrap().attribute_value("city"), Some("Prague"));
+        assert_eq!(
+            x.for_dimension("geo").unwrap().attribute_value("city"),
+            Some("Prague")
+        );
         assert_eq!(x.to_string(), s);
     }
 
@@ -254,7 +301,10 @@ mod tests {
 
     #[test]
     fn without_dimension() {
-        let x = XUnit::new(vec![geo(), YPath::new("gender").with_attribute("gender", "F")]);
+        let x = XUnit::new(vec![
+            geo(),
+            YPath::new("gender").with_attribute("gender", "F"),
+        ]);
         let stripped = x.without_dimension("geo");
         assert_eq!(stripped.num_dimensions(), 1);
         assert!(!stripped.contains_dimension("geo"));

--- a/crates/cubism-core/tests/properties.rs
+++ b/crates/cubism-core/tests/properties.rs
@@ -3,9 +3,9 @@
 //! - binary key encode/decode round-trip and key canonicality
 //! - pruned lattice generation ≡ generate-everything-then-filter
 
-use cubism_core::encoding::{decode_xunit, encode_xunit, XUnitDictionary};
+use cubism_core::encoding::{XUnitDictionary, decode_xunit, encode_xunit};
 use cubism_core::lattice::{generate_xunits, generate_xunits_unpruned};
-use cubism_core::rules::{include_xunit, FilterRule};
+use cubism_core::rules::{FilterRule, include_xunit};
 use cubism_core::sketch::KmvSketch;
 use cubism_core::{XUnit, YPath};
 use proptest::prelude::*;
@@ -27,7 +27,13 @@ fn ident_strategy() -> impl Strategy<Value = String> {
 fn ypath_strategy() -> impl Strategy<Value = YPath> {
     (
         ident_strategy(),
-        prop::collection::vec((ident_strategy(), prop::option::weighted(0.9, value_strategy())), 1..4),
+        prop::collection::vec(
+            (
+                ident_strategy(),
+                prop::option::weighted(0.9, value_strategy()),
+            ),
+            1..4,
+        ),
     )
         .prop_map(|(dim, attributes)| YPath { dim, attributes })
 }
@@ -45,7 +51,10 @@ fn xunit_strategy() -> impl Strategy<Value = XUnit> {
 /// Per-dimension YPath alternatives shaped like real hierarchy prefixes.
 fn per_dimension_strategy() -> impl Strategy<Value = Vec<Vec<YPath>>> {
     prop::collection::vec(
-        (ident_strategy(), prop::collection::vec((ident_strategy(), value_strategy()), 0..3)),
+        (
+            ident_strategy(),
+            prop::collection::vec((ident_strategy(), value_strategy()), 0..3),
+        ),
         1..4,
     )
     .prop_map(|dims| {
@@ -73,8 +82,7 @@ fn rules_strategy() -> impl Strategy<Value = Vec<FilterRule>> {
         dim.clone().prop_map(|d| FilterRule::ContainsDim { dim: d }),
         dim.clone().prop_map(|d| FilterRule::TopLevel { dim: d }),
         dim.clone().prop_map(|d| FilterRule::NotAlone { dim: d }),
-        (dim.clone(), dim.clone())
-            .prop_map(|(a, b)| FilterRule::NotTogether { dims: vec![a, b] }),
+        (dim.clone(), dim.clone()).prop_map(|(a, b)| FilterRule::NotTogether { dims: vec![a, b] }),
     ];
     let combined = leaf.clone().prop_recursive(2, 8, 3, |inner| {
         prop_oneof![

--- a/crates/cubism-correct/src/engine.rs
+++ b/crates/cubism-correct/src/engine.rs
@@ -46,13 +46,11 @@ use arrow_array::RecordBatch;
 use cubism_core::temporal::{TimeRange, WindowId, WindowRevision};
 use cubism_core::{AggKind, CubeSpec};
 use cubism_datafusion::datafusion::prelude::SessionContext;
-use cubism_datafusion::temporal_build::{build_temporal, NullEventTimePolicy};
-use cubism_iceberg::{
-    CorrectionCoordinator, CorrectionRequest, PublicationStore, TemporalTable,
-};
+use cubism_datafusion::temporal_build::{NullEventTimePolicy, build_temporal};
+use cubism_iceberg::{CorrectionCoordinator, CorrectionRequest, PublicationStore, TemporalTable};
 
-use crate::windows::{affected_windows, AffectedWindow};
 use crate::CorrectError;
+use crate::windows::{AffectedWindow, affected_windows};
 
 /// One window's correction result.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/cubism-correct/src/lib.rs
+++ b/crates/cubism-correct/src/lib.rs
@@ -24,8 +24,8 @@
 pub mod engine;
 pub mod windows;
 
-pub use engine::{CorrectionOutcome, CorrectionEngine, WindowCorrection};
-pub use windows::{affected_windows, window_id_for, AffectedWindow};
+pub use engine::{CorrectionEngine, CorrectionOutcome, WindowCorrection};
+pub use windows::{AffectedWindow, affected_windows, window_id_for};
 
 /// This crate's error type. Deliberately keeps the two underlying failure
 /// domains distinguishable rather than flattening them to strings: a
@@ -65,6 +65,8 @@ pub enum CorrectError {
     Rebuild(#[from] cubism_datafusion::datafusion::error::DataFusionError),
     #[error(transparent)]
     Persist(#[from] cubism_iceberg::CubismIcebergError),
-    #[error("window '{window_id}' has never been published; a correction revises an existing window, it does not create one")]
+    #[error(
+        "window '{window_id}' has never been published; a correction revises an existing window, it does not create one"
+    )]
     UnpublishedWindow { window_id: String },
 }

--- a/crates/cubism-correct/src/windows.rs
+++ b/crates/cubism-correct/src/windows.rs
@@ -33,7 +33,7 @@
 //! `build_temporal_demo.sh` already passes to `--window-id`, so warehouses
 //! built before this module resolve through it unchanged. That
 //! compatibility is asserted in this module's tests, not assumed —
-//! [`day_form_matches_the_existing_demo_convention`].
+//! `day_form_matches_the_existing_demo_convention`.
 //!
 //! # Why the encoding must be injective, and how the third form arose
 //!
@@ -101,7 +101,9 @@ pub fn window_id_for(
 ) -> Result<WindowId, CorrectError> {
     let micros = bucket_start.unix_micros();
     let timestamp = DateTime::<Utc>::from_timestamp_micros(micros).ok_or_else(|| {
-        CorrectError::WindowNaming(format!("bucket start {micros}µs is out of representable range"))
+        CorrectError::WindowNaming(format!(
+            "bucket start {micros}µs is out of representable range"
+        ))
     })?;
     // A whole number of days, and the bucket actually lands on a midnight:
     // a 1d resolution with a non-midnight origin is still sub-day-aligned
@@ -172,13 +174,14 @@ pub fn affected_windows(
 
     let mut windows = Vec::new();
     for step in 0..count {
-        let start = first
-            .start
-            .unix_micros()
-            .checked_add(step.checked_mul(width).ok_or_else(|| {
-                CorrectError::WindowNaming("window enumeration overflows".into())
-            })?)
-            .ok_or_else(|| CorrectError::WindowNaming("window enumeration overflows".into()))?;
+        let start =
+            first
+                .start
+                .unix_micros()
+                .checked_add(step.checked_mul(width).ok_or_else(|| {
+                    CorrectError::WindowNaming("window enumeration overflows".into())
+                })?)
+                .ok_or_else(|| CorrectError::WindowNaming("window enumeration overflows".into()))?;
         let end = start
             .checked_add(width)
             .ok_or_else(|| CorrectError::WindowNaming("window end overflows".into()))?;
@@ -204,7 +207,9 @@ mod tests {
         TemporalSpec {
             event_time: "timestamp".into(),
             ingestion_time: None,
-            base_resolution: Resolution::Fixed(FixedResolution::from_micros(MICROS_PER_DAY).unwrap()),
+            base_resolution: Resolution::Fixed(
+                FixedResolution::from_micros(MICROS_PER_DAY).unwrap(),
+            ),
             origin: BucketOrigin::default(),
             timezone: "UTC".into(),
             allowed_lateness: AllowedLateness::from_micros(0).unwrap(),
@@ -214,9 +219,7 @@ mod tests {
     }
 
     fn at(text: &str) -> EventTime {
-        EventTime::from_unix_micros(
-            text.parse::<DateTime<Utc>>().unwrap().timestamp_micros(),
-        )
+        EventTime::from_unix_micros(text.parse::<DateTime<Utc>>().unwrap().timestamp_micros())
     }
 
     /// The compatibility constraint this whole encoding is pinned by: the
@@ -227,7 +230,10 @@ mod tests {
     fn day_form_matches_the_existing_demo_convention() {
         let resolution = FixedResolution::from_micros(MICROS_PER_DAY).unwrap();
         let start = BucketStart::from_unix_micros(at("2026-04-06T00:00:00Z").unix_micros());
-        assert_eq!(window_id_for(start, resolution).unwrap().as_str(), "2026-04-06");
+        assert_eq!(
+            window_id_for(start, resolution).unwrap().as_str(),
+            "2026-04-06"
+        );
     }
 
     #[test]
@@ -264,7 +270,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            windows.iter().map(|w| w.window_id.as_str()).collect::<Vec<_>>(),
+            windows
+                .iter()
+                .map(|w| w.window_id.as_str())
+                .collect::<Vec<_>>(),
             ["2026-04-06"]
         );
 
@@ -279,7 +288,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            windows.iter().map(|w| w.window_id.as_str()).collect::<Vec<_>>(),
+            windows
+                .iter()
+                .map(|w| w.window_id.as_str())
+                .collect::<Vec<_>>(),
             ["2026-04-06", "2026-04-07"]
         );
     }
@@ -292,7 +304,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            windows.iter().map(|w| w.window_id.as_str()).collect::<Vec<_>>(),
+            windows
+                .iter()
+                .map(|w| w.window_id.as_str())
+                .collect::<Vec<_>>(),
             ["2026-04-06", "2026-04-07", "2026-04-08", "2026-04-09"]
         );
         // Contiguous: each window's end is the next one's start.
@@ -320,7 +335,12 @@ mod tests {
     fn adjacent_microsecond_buckets_do_not_collide() {
         let one_us = FixedResolution::from_micros(1).unwrap();
         let ids: Vec<String> = (0..4)
-            .map(|n| window_id_for(BucketStart::from_unix_micros(n), one_us).unwrap().as_str().to_string())
+            .map(|n| {
+                window_id_for(BucketStart::from_unix_micros(n), one_us)
+                    .unwrap()
+                    .as_str()
+                    .to_string()
+            })
             .collect();
         assert_eq!(
             ids,
@@ -343,9 +363,18 @@ mod tests {
         // Straddles a second boundary and the epoch, so both the
         // whole-second/sub-second split and the negative path are covered.
         let ids: HashSet<String> = (-2_000..2_000)
-            .map(|n| window_id_for(BucketStart::from_unix_micros(n), one_us).unwrap().as_str().to_string())
+            .map(|n| {
+                window_id_for(BucketStart::from_unix_micros(n), one_us)
+                    .unwrap()
+                    .as_str()
+                    .to_string()
+            })
             .collect();
-        assert_eq!(ids.len(), 4_000, "every distinct bucket start needs a distinct id");
+        assert_eq!(
+            ids.len(),
+            4_000,
+            "every distinct bucket start needs a distinct id"
+        );
     }
 
     /// Pre-epoch bucket starts are classified by where they sit inside
@@ -354,11 +383,15 @@ mod tests {
     fn pre_epoch_sub_second_buckets_render_correctly() {
         let half_sec = FixedResolution::from_micros(500_000).unwrap();
         assert_eq!(
-            window_id_for(BucketStart::from_unix_micros(-500_000), half_sec).unwrap().as_str(),
+            window_id_for(BucketStart::from_unix_micros(-500_000), half_sec)
+                .unwrap()
+                .as_str(),
             "1969-12-31T23:59:59.500000Z"
         );
         assert_eq!(
-            window_id_for(BucketStart::from_unix_micros(-1_000_000), half_sec).unwrap().as_str(),
+            window_id_for(BucketStart::from_unix_micros(-1_000_000), half_sec)
+                .unwrap()
+                .as_str(),
             "1969-12-31T23:59:59Z"
         );
     }

--- a/crates/cubism-correct/tests/recompute_equality.rs
+++ b/crates/cubism-correct/tests/recompute_equality.rs
@@ -30,12 +30,12 @@
 use std::sync::Arc;
 
 use arrow_array::{Array, FixedSizeBinaryArray, RecordBatch, TimestampMicrosecondArray};
-use cubism_core::temporal::{EventTime, TimeRange, WindowId, WindowRevision};
 use cubism_core::CubeSpec;
+use cubism_core::temporal::{EventTime, TimeRange, WindowId, WindowRevision};
 use cubism_correct::{CorrectError, CorrectionEngine, CorrectionOutcome};
 use cubism_datafusion::datafusion::prelude::{CsvReadOptions, SessionContext};
 use cubism_datafusion::temporal_build::{
-    build_temporal, temporal_state_schema, NullEventTimePolicy,
+    NullEventTimePolicy, build_temporal, temporal_state_schema,
 };
 use cubism_iceberg::{
     AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, ClaimResult, PublicationStore,
@@ -98,7 +98,9 @@ fn write_csv(dir: &TempDir, name: &str, body: &str) -> String {
 
 fn at(text: &str) -> EventTime {
     EventTime::from_unix_micros(
-        chrono::DateTime::parse_from_rfc3339(text).unwrap().timestamp_micros(),
+        chrono::DateTime::parse_from_rfc3339(text)
+            .unwrap()
+            .timestamp_micros(),
     )
 }
 
@@ -113,11 +115,20 @@ struct Warehouse {
 impl Warehouse {
     async fn new(spec: &CubeSpec) -> Self {
         let dir = TempDir::new().unwrap();
-        let config = CatalogConfig::Memory { warehouse: dir.path().to_path_buf() };
+        let config = CatalogConfig::Memory {
+            warehouse: dir.path().to_path_buf(),
+        };
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
         let schema = temporal_state_schema(spec).unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), &spec.name, &schema).await.unwrap();
-        Self { _dir: dir, catalog, table, publications: PublicationStore::in_memory() }
+        let table = TemporalTable::create(catalog.as_ref(), &spec.name, &schema)
+            .await
+            .unwrap();
+        Self {
+            _dir: dir,
+            catalog,
+            table,
+            publications: PublicationStore::in_memory(),
+        }
     }
 
     /// Build `window_id` from `source` and publish it as revision 1 through
@@ -147,7 +158,13 @@ impl Warehouse {
         let revision = WindowRevision::new(1).unwrap();
         let claim = self
             .publications
-            .claim_run(&self.table.cube_id, window_id, run_id, revision, expected_rows)
+            .claim_run(
+                &self.table.cube_id,
+                window_id,
+                run_id,
+                revision,
+                expected_rows,
+            )
             .await
             .unwrap();
         assert!(matches!(claim, ClaimResult::New(_)));
@@ -164,7 +181,10 @@ impl Warehouse {
         )
         .await
         .unwrap();
-        self.publications.record_append(run_id, result.snapshot_id).await.unwrap();
+        self.publications
+            .record_append(run_id, result.snapshot_id)
+            .await
+            .unwrap();
         self.publications.publish(run_id, None).await.unwrap();
     }
 
@@ -246,8 +266,11 @@ async fn a_late_event_rebuild_equals_a_clean_rebuild_from_the_corrected_source()
     let corrected_csv = write_csv(&dir, "corrected.csv", &format!("{BASE_ROWS}{LATE_ROWS}"));
 
     let day2 = WindowId::new("2026-04-07").unwrap();
-    let day2_range =
-        TimeRange::new(at("2026-04-07T00:00:00+00:00"), at("2026-04-08T00:00:00+00:00")).unwrap();
+    let day2_range = TimeRange::new(
+        at("2026-04-07T00:00:00+00:00"),
+        at("2026-04-08T00:00:00+00:00"),
+    )
+    .unwrap();
 
     // ---- Path A: publish the partial window, then correct it -----------
     let ctx_a = SessionContext::new();
@@ -269,7 +292,11 @@ async fn a_late_event_rebuild_equals_a_clean_rebuild_from_the_corrected_source()
         &ctx_a,
         &spec,
         "corrected",
-        TimeRange::new(at("2026-04-07T09:00:00+00:00"), at("2026-04-07T11:00:01+00:00")).unwrap(),
+        TimeRange::new(
+            at("2026-04-07T09:00:00+00:00"),
+            at("2026-04-07T11:00:01+00:00"),
+        )
+        .unwrap(),
         a.catalog.as_ref(),
         &a.table,
         &a.publications,
@@ -282,7 +309,11 @@ async fn a_late_event_rebuild_equals_a_clean_rebuild_from_the_corrected_source()
     let corrected = &outcome.corrected[0];
     assert_eq!(corrected.window_id.as_str(), "2026-04-07");
     assert_eq!(corrected.previous_revision.get(), 1);
-    assert_eq!(corrected.revision.get(), 2, "the correction bumped the revision");
+    assert_eq!(
+        corrected.revision.get(),
+        2,
+        "the correction bumped the revision"
+    );
     assert!(outcome.skipped_unpublished.is_empty());
 
     // ---- Path B: a clean, single-revision build from corrected source --
@@ -299,7 +330,10 @@ async fn a_late_event_rebuild_equals_a_clean_rebuild_from_the_corrected_source()
     let corrected_rows = domain_rows(&a.read(&day2).await);
     let clean_rows = domain_rows(&b.read(&day2).await);
 
-    assert!(!clean_rows.is_empty(), "the clean build produced rows to compare");
+    assert!(
+        !clean_rows.is_empty(),
+        "the clean build produced rows to compare"
+    );
     assert_eq!(
         corrected_rows, clean_rows,
         "a late-event rebuild must equal a clean rebuild from the corrected source"
@@ -351,8 +385,16 @@ async fn a_change_spanning_days_corrects_each_published_window_and_reports_unpub
 
     // Publish only two of the three days the range below spans.
     for (day, start, end) in [
-        ("2026-04-06", "2026-04-06T00:00:00+00:00", "2026-04-07T00:00:00+00:00"),
-        ("2026-04-08", "2026-04-08T00:00:00+00:00", "2026-04-09T00:00:00+00:00"),
+        (
+            "2026-04-06",
+            "2026-04-06T00:00:00+00:00",
+            "2026-04-07T00:00:00+00:00",
+        ),
+        (
+            "2026-04-08",
+            "2026-04-08T00:00:00+00:00",
+            "2026-04-09T00:00:00+00:00",
+        ),
     ] {
         let window = WindowId::new(day).unwrap();
         w.build_and_publish_initial(
@@ -370,7 +412,11 @@ async fn a_change_spanning_days_corrects_each_published_window_and_reports_unpub
         &ctx,
         &spec,
         "corrected",
-        TimeRange::new(at("2026-04-06T12:00:00+00:00"), at("2026-04-08T12:00:00+00:00")).unwrap(),
+        TimeRange::new(
+            at("2026-04-06T12:00:00+00:00"),
+            at("2026-04-08T12:00:00+00:00"),
+        )
+        .unwrap(),
         w.catalog.as_ref(),
         &w.table,
         &w.publications,
@@ -380,7 +426,11 @@ async fn a_change_spanning_days_corrects_each_published_window_and_reports_unpub
     .unwrap();
 
     assert_eq!(
-        outcome.corrected.iter().map(|c| c.window_id.as_str()).collect::<Vec<_>>(),
+        outcome
+            .corrected
+            .iter()
+            .map(|c| c.window_id.as_str())
+            .collect::<Vec<_>>(),
         ["2026-04-06", "2026-04-08"],
         "every published window in the range is corrected, in time order"
     );
@@ -388,7 +438,11 @@ async fn a_change_spanning_days_corrects_each_published_window_and_reports_unpub
     // 2026-04-07 was never published: a correction revises an existing
     // window, it must not conjure one into being.
     assert_eq!(
-        outcome.skipped_unpublished.iter().map(WindowId::as_str).collect::<Vec<_>>(),
+        outcome
+            .skipped_unpublished
+            .iter()
+            .map(WindowId::as_str)
+            .collect::<Vec<_>>(),
         ["2026-04-07"]
     );
     assert!(
@@ -431,8 +485,16 @@ async fn a_failure_part_way_through_reports_the_windows_that_already_landed() {
 
     // 2026-04-06 and 2026-04-08 published; 2026-04-07 deliberately not.
     for (day, start, end) in [
-        ("2026-04-06", "2026-04-06T00:00:00+00:00", "2026-04-07T00:00:00+00:00"),
-        ("2026-04-08", "2026-04-08T00:00:00+00:00", "2026-04-09T00:00:00+00:00"),
+        (
+            "2026-04-06",
+            "2026-04-06T00:00:00+00:00",
+            "2026-04-07T00:00:00+00:00",
+        ),
+        (
+            "2026-04-08",
+            "2026-04-08T00:00:00+00:00",
+            "2026-04-09T00:00:00+00:00",
+        ),
     ] {
         let window = WindowId::new(day).unwrap();
         w.build_and_publish_initial(
@@ -463,7 +525,11 @@ async fn a_failure_part_way_through_reports_the_windows_that_already_landed() {
         &ctx,
         &spec,
         "corrected",
-        TimeRange::new(at("2026-04-06T12:00:00+00:00"), at("2026-04-08T12:00:00+00:00")).unwrap(),
+        TimeRange::new(
+            at("2026-04-06T12:00:00+00:00"),
+            at("2026-04-08T12:00:00+00:00"),
+        )
+        .unwrap(),
         w.catalog.as_ref(),
         &w.table,
         &w.publications,
@@ -472,19 +538,30 @@ async fn a_failure_part_way_through_reports_the_windows_that_already_landed() {
     .await
     .expect_err("the poisoned second window must fail the run");
 
-    let CorrectError::Partial { corrected, skipped_unpublished, source } = err else {
+    let CorrectError::Partial {
+        corrected,
+        skipped_unpublished,
+        source,
+    } = err
+    else {
         panic!("a mid-run failure must surface as CorrectError::Partial, got: {err:?}");
     };
 
     // The prefix is REPORTED...
     assert_eq!(
-        corrected.iter().map(|c| c.window_id.as_str()).collect::<Vec<_>>(),
+        corrected
+            .iter()
+            .map(|c| c.window_id.as_str())
+            .collect::<Vec<_>>(),
         ["2026-04-06"],
         "the window corrected before the failure must travel out with the error"
     );
     assert_eq!(corrected[0].revision.get(), 2);
     assert_eq!(
-        skipped_unpublished.iter().map(WindowId::as_str).collect::<Vec<_>>(),
+        skipped_unpublished
+            .iter()
+            .map(WindowId::as_str)
+            .collect::<Vec<_>>(),
         ["2026-04-07"],
         "never-published windows are still reported on the failure path"
     );
@@ -506,7 +583,12 @@ async fn a_failure_part_way_through_reports_the_windows_that_already_landed() {
         "the corrected prefix really was published"
     );
     assert_eq!(
-        w.publications.current(&w.table.cube_id, &poisoned).await.unwrap().unwrap().get(),
+        w.publications
+            .current(&w.table.cube_id, &poisoned)
+            .await
+            .unwrap()
+            .unwrap()
+            .get(),
         1,
         "the failed window was left at its original revision"
     );

--- a/crates/cubism-datafusion/src/build.rs
+++ b/crates/cubism-datafusion/src/build.rs
@@ -23,9 +23,9 @@
 //! by DataFusion — that's the design: the spec's `expr` fields are the
 //! engine's expression language.
 
-use crate::udf::{cube_udfs, SharedDictionary};
+use crate::udf::{SharedDictionary, cube_udfs};
 use cubism_core::{AggKind, CubeSpec};
-use datafusion::common::{plan_err, Result};
+use datafusion::common::{Result, plan_err};
 use datafusion::dataframe::DataFrame;
 use datafusion::execution::context::SessionContext;
 
@@ -37,7 +37,8 @@ pub async fn build_cube(
     spec: &CubeSpec,
     source: &str,
 ) -> Result<(DataFrame, SharedDictionary)> {
-    spec.validate().map_err(|e| datafusion::common::DataFusionError::Plan(e.to_string()))?;
+    spec.validate()
+        .map_err(|e| datafusion::common::DataFusionError::Plan(e.to_string()))?;
 
     let (keys_udf, decode_udf, dict) = cube_udfs(spec);
     ctx.register_udf(keys_udf);
@@ -67,7 +68,10 @@ pub(crate) fn level_columns(spec: &CubeSpec) -> (Vec<String>, Vec<String>) {
     for dim in spec.sorted_dimensions() {
         for level in dim.effective_levels() {
             let alias = format!("__l{}", level_args.len());
-            level_selects.push(format!("CAST({} AS VARCHAR) AS {alias}", level.expression()));
+            level_selects.push(format!(
+                "CAST({} AS VARCHAR) AS {alias}",
+                level.expression()
+            ));
             level_args.push(alias);
         }
     }
@@ -124,21 +128,25 @@ pub fn cube_sql(spec: &CubeSpec, source: &str) -> Result<String> {
                 measure_selects.push(format!("CAST({by} AS DOUBLE) AS {alias}s"));
                 passthrough.push(format!("{alias}k"));
                 passthrough.push(format!("{alias}s"));
-                agg_selects
-                    .push(format!("cubism_topk_sketch({alias}k, {alias}s) AS \"{name}__sketch\""));
+                agg_selects.push(format!(
+                    "cubism_topk_sketch({alias}k, {alias}s) AS \"{name}__sketch\""
+                ));
                 final_cols.push(sketch_finals("cubism_topk_json"));
             }
             AggKind::ReservoirSample => {
                 measure_selects.push(format!("CAST({} AS VARCHAR) AS {alias}", input()));
                 passthrough.push(alias.clone());
-                agg_selects.push(format!("cubism_sample_sketch({alias}) AS \"{name}__sketch\""));
+                agg_selects.push(format!(
+                    "cubism_sample_sketch({alias}) AS \"{name}__sketch\""
+                ));
                 final_cols.push(sketch_finals("cubism_sample_json"));
             }
             AggKind::Centroid => {
                 measure_selects.push(format!("{} AS {alias}", input()));
                 passthrough.push(alias.clone());
-                agg_selects
-                    .push(format!("cubism_centroid_sketch({alias}) AS \"{name}__sketch\""));
+                agg_selects.push(format!(
+                    "cubism_centroid_sketch({alias}) AS \"{name}__sketch\""
+                ));
                 final_cols.push(sketch_finals("cubism_centroid_mean"));
             }
             AggKind::Quantile | AggKind::Variance => {
@@ -153,7 +161,11 @@ pub fn cube_sql(spec: &CubeSpec, source: &str) -> Result<String> {
         return plan_err!("cube spec has no measures");
     }
 
-    let input_cols = level_selects.iter().chain(&measure_selects).cloned().collect::<Vec<_>>();
+    let input_cols = level_selects
+        .iter()
+        .chain(&measure_selects)
+        .cloned()
+        .collect::<Vec<_>>();
     Ok(format!(
         "WITH __cubism_input AS (\n  SELECT {input}\n  FROM {source}\n),\n\
          __cubism_exploded AS (\n  SELECT unnest(cubism_xunit_keys({args})) AS __xunit_key{measures}\n  FROM __cubism_input\n),\n\
@@ -161,7 +173,10 @@ pub fn cube_sql(spec: &CubeSpec, source: &str) -> Result<String> {
          SELECT cubism_xunit_str(__xunit_key) AS xunit, {finals}\nFROM __cubism_cells",
         input = input_cols.join(", "),
         args = level_args.join(", "),
-        measures = passthrough.iter().map(|a| format!(", {a}")).collect::<String>(),
+        measures = passthrough
+            .iter()
+            .map(|a| format!(", {a}"))
+            .collect::<String>(),
         aggs = agg_selects.join(", "),
         finals = final_cols.join(", "),
     ))
@@ -186,9 +201,24 @@ mod tests {
         RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(StringArray::from(vec![Some("CZ"), Some("CZ"), Some("US"), None])),
-                Arc::new(StringArray::from(vec![Some("Prague"), Some("Brno"), None, None])),
-                Arc::new(StringArray::from(vec![Some("F"), Some("M"), Some("F"), Some("F")])),
+                Arc::new(StringArray::from(vec![
+                    Some("CZ"),
+                    Some("CZ"),
+                    Some("US"),
+                    None,
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("Prague"),
+                    Some("Brno"),
+                    None,
+                    None,
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("F"),
+                    Some("M"),
+                    Some("F"),
+                    Some("F"),
+                ])),
                 Arc::new(Int64Array::from(vec![10, 20, 40, 80])),
                 Arc::new(StringArray::from(vec!["u1", "u2", "u1", "u3"])),
             ],
@@ -221,9 +251,21 @@ includeGlobal: true
 
         let mut cells = HashMap::new();
         for batch in &batches {
-            let xunit = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-            let pvs = batch.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
-            let events = batch.column(2).as_any().downcast_ref::<Int64Array>().unwrap();
+            let xunit = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let pvs = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let events = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
             for i in 0..batch.num_rows() {
                 cells.insert(xunit.value(i).to_string(), (pvs.value(i), events.value(i)));
             }
@@ -252,7 +294,10 @@ includeGlobal: true
         ctx.register_batch("events", sample_batch()).unwrap();
         let (df, _dict) = build_cube(&ctx, &spec, "events").await.unwrap();
         let err = df.collect().await.unwrap_err().to_string();
-        assert!(err.contains("maxDictionaryEntries"), "unexpected error: {err}");
+        assert!(
+            err.contains("maxDictionaryEntries"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
@@ -271,7 +316,10 @@ includeGlobal: true
         assert_eq!(cells["/gender/gender=F"], (130, 3));
         // Cross cells combine dimensions.
         assert_eq!(cells["/gender/gender=F,/geo/country=CZ"], (10, 1));
-        assert_eq!(cells["/gender/gender=F,/geo/country=CZ/city=Prague"], (10, 1));
+        assert_eq!(
+            cells["/gender/gender=F,/geo/country=CZ/city=Prague"],
+            (10, 1)
+        );
 
         // Distinct cells across all rows: geo {CZ, CZ/Prague, CZ/Brno, US} +
         // gender {F, M} + crosses {CZ+F, CZ/Prague+F, CZ+M, CZ/Brno+M, US+F}
@@ -320,9 +368,21 @@ includeGlobal: true
 
         let mut cells: HashMap<String, (String, String)> = HashMap::new();
         for batch in &batches {
-            let xunit = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-            let topk = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
-            let sample = batch.column(3).as_any().downcast_ref::<StringArray>().unwrap();
+            let xunit = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let topk = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let sample = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
             for i in 0..batch.num_rows() {
                 cells.insert(
                     xunit.value(i).to_string(),
@@ -333,7 +393,10 @@ includeGlobal: true
 
         // Global: Prague pv=10, Brno pv=20 (rows 3,4 have null city — no key).
         let (topk, sample) = &cells["/G"];
-        assert_eq!(topk, r#"[{"key":"Brno","score":20.0},{"key":"Prague","score":10.0}]"#);
+        assert_eq!(
+            topk,
+            r#"[{"key":"Brno","score":20.0},{"key":"Prague","score":10.0}]"#
+        );
         // Distinct users u1,u2,u3 all fit in the sample.
         let users: Vec<String> = serde_json::from_str(sample).unwrap();
         let mut sorted = users.clone();
@@ -389,7 +452,11 @@ measures:
 
         let batch = &batches[0];
         assert_eq!(batch.num_rows(), 1); // one cell: /channel/channel=eng
-        let means = batch.column(1).as_any().downcast_ref::<ListArray>().unwrap();
+        let means = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
         let mean = means.value(0);
         let mean = mean
             .as_any()
@@ -423,13 +490,27 @@ measures:
         let mut reach = HashMap::new();
         let mut sketches: HashMap<String, KmvSketch> = HashMap::new();
         for batch in &batches {
-            let xunit = batch.column(0).as_any().downcast_ref::<StringArray>().unwrap();
-            let est = batch.column(1).as_any().downcast_ref::<Float64Array>().unwrap();
-            let blob = batch.column(2).as_any().downcast_ref::<BinaryArray>().unwrap();
+            let xunit = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let est = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            let blob = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .unwrap();
             for i in 0..batch.num_rows() {
                 reach.insert(xunit.value(i).to_string(), est.value(i));
-                sketches
-                    .insert(xunit.value(i).to_string(), KmvSketch::from_bytes(blob.value(i)).unwrap());
+                sketches.insert(
+                    xunit.value(i).to_string(),
+                    KmvSketch::from_bytes(blob.value(i)).unwrap(),
+                );
             }
         }
 

--- a/crates/cubism-datafusion/src/state_udaf.rs
+++ b/crates/cubism-datafusion/src/state_udaf.rs
@@ -24,7 +24,7 @@
 use cubism_core::{AggKind, AggregateState, AverageState, CubeSpec, QuantileState, VarianceState};
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, Float64Builder, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion::common::{exec_err, Result, ScalarValue};
+use datafusion::common::{Result, ScalarValue, exec_err};
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion::logical_expr::{
     Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, ScalarFunctionArgs, ScalarUDF,
@@ -38,7 +38,9 @@ fn to_df_err(e: cubism_core::CubismError) -> datafusion::common::DataFusionError
 
 fn iter_blobs(array: &ArrayRef) -> impl Iterator<Item = &[u8]> {
     let arr = array.as_binary::<i32>();
-    (0..arr.len()).filter(|&i| !arr.is_null(i)).map(move |i| arr.value(i))
+    (0..arr.len())
+        .filter(|&i| !arr.is_null(i))
+        .map(move |i| arr.value(i))
 }
 
 fn f64_input(values: &[ArrayRef]) -> impl Iterator<Item = f64> + '_ {
@@ -72,11 +74,17 @@ impl AggregateUDFImpl for AverageStateUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(AverageAccumulator { state: AverageState::new() }))
+        Ok(Box::new(AverageAccumulator {
+            state: AverageState::new(),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[avg]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[avg]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 }
 
@@ -174,11 +182,17 @@ impl AggregateUDFImpl for VarianceStateUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(VarianceAccumulator { state: VarianceState::new() }))
+        Ok(Box::new(VarianceAccumulator {
+            state: VarianceState::new(),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[variance]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[variance]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 }
 
@@ -307,7 +321,11 @@ impl AggregateUDFImpl for QuantileStateUdaf {
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[quantile]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[quantile]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 }
 
@@ -403,12 +421,20 @@ pub fn state_udafs() -> (Vec<AggregateUDF>, Vec<ScalarUDF>) {
     let blob_arg = || Signature::exact(vec![DataType::Binary], Volatility::Immutable);
     (
         vec![
-            AggregateUDF::from(AverageStateUdaf { signature: double_arg() }),
-            AggregateUDF::from(VarianceStateUdaf { signature: double_arg() }),
+            AggregateUDF::from(AverageStateUdaf {
+                signature: double_arg(),
+            }),
+            AggregateUDF::from(VarianceStateUdaf {
+                signature: double_arg(),
+            }),
         ],
         vec![
-            ScalarUDF::from(AveragePresentUdf { signature: blob_arg() }),
-            ScalarUDF::from(VariancePresentUdf { signature: blob_arg() }),
+            ScalarUDF::from(AveragePresentUdf {
+                signature: blob_arg(),
+            }),
+            ScalarUDF::from(VariancePresentUdf {
+                signature: blob_arg(),
+            }),
         ],
     )
 }
@@ -524,7 +550,10 @@ mod tests {
 
     #[test]
     fn quantile_udaf_names_are_namespaced_per_measure() {
-        assert_eq!(quantile_state_udaf_name("latency_p50"), "cubism_quantile_state__latency_p50");
+        assert_eq!(
+            quantile_state_udaf_name("latency_p50"),
+            "cubism_quantile_state__latency_p50"
+        );
         assert_eq!(
             quantile_present_udf_name("latency_p50"),
             "cubism_quantile_present__latency_p50"

--- a/crates/cubism-datafusion/src/temporal_build.rs
+++ b/crates/cubism-datafusion/src/temporal_build.rs
@@ -4,14 +4,14 @@
 //! group -> present) but:
 //!
 //! 1. evaluates the spec's `temporal.eventTime` expression and assigns each
-//!    row to one half-open UTC bucket via [`cubism_bucket_start`], reusing
+//!    row to one half-open UTC bucket via `cubism_bucket_start`, reusing
 //!    `cubism_core::temporal::FixedResolution::bucket`'s exact math (the same
 //!    euclidean-division code the pre-origin/boundary tests in
 //!    `cubism-core` already cover) instead of re-deriving bucket arithmetic
 //!    in SQL or in this crate;
 //! 2. generates the *same* row-local XUnits the static path would (same
 //!    `level_columns`/`cubism_xunit_keys` UDF, same lattice/rules code in
-//!    `cubism-core` — see [`crate::build::level_columns`]);
+//!    `cubism-core` — see `crate::build::level_columns`);
 //! 3. appends bucket identity to the `GROUP BY` key as an ordinary extra
 //!    column, never as another XUnit dimension — a temporal build's cells
 //!    are keyed by `(bucket, xunit)`, and the lattice itself never sees time;
@@ -42,11 +42,11 @@
 use crate::build::level_columns;
 use crate::state_udaf::{quantile_state_udaf_name, quantile_state_udafs, state_udafs};
 use crate::udaf::sketch_udfs;
-use crate::udf::{cube_udfs, SharedDictionary};
+use crate::udf::{SharedDictionary, cube_udfs};
 use cubism_core::encoding::{canonical_xunit_content_id, decode_xunit, encode_canonical_xunit};
 use cubism_core::spec::API_VERSION_V2_ALPHA1;
 use cubism_core::{
-    AggKind, BucketOrigin, CanonicalXUnit, Coverage, CubeSpec, Exactness, EventTime,
+    AggKind, BucketOrigin, CanonicalXUnit, Coverage, CubeSpec, EventTime, Exactness,
     FixedResolution, MeasureSpec, Resolution, TemporalSpec, TimeRange, WindowId,
 };
 use datafusion::arrow::array::{
@@ -56,7 +56,7 @@ use datafusion::arrow::datatypes::{
     DataType, Field, Schema, TimeUnit, TimestampMicrosecondType, TimestampMillisecondType,
     TimestampNanosecondType, TimestampSecondType,
 };
-use datafusion::common::{plan_err, DataFusionError, Result};
+use datafusion::common::{DataFusionError, Result, plan_err};
 use datafusion::dataframe::{DataFrame, DataFrameWriteOptions};
 use datafusion::execution::context::SessionContext;
 use datafusion::functions_aggregate::expr_fn::{max, min};
@@ -204,9 +204,10 @@ fn extract_timestamp_micros(array: &ArrayRef, unit: TimeUnit) -> Result<Vec<Opti
             .iter()
             .map(|v| v.map(|v| scale_up(v, 1_000)).transpose())
             .collect(),
-        TimeUnit::Microsecond => {
-            Ok(array.as_primitive::<TimestampMicrosecondType>().iter().collect())
-        }
+        TimeUnit::Microsecond => Ok(array
+            .as_primitive::<TimestampMicrosecondType>()
+            .iter()
+            .collect()),
         // Sub-microsecond precision is discarded, not rounded: bucket
         // boundaries are never finer than microseconds, so floor-toward
         // negative-infinity (not truncation) keeps pre-epoch timestamps
@@ -229,7 +230,10 @@ impl ScalarUDFImpl for BucketStartUdf {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())))
+        Ok(DataType::Timestamp(
+            TimeUnit::Microsecond,
+            Some("+00:00".into()),
+        ))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -251,7 +255,9 @@ impl ScalarUDFImpl for BucketStartUdf {
                 Some(us) => Some(
                     self.resolution
                         .bucket(EventTime::from_unix_micros(us), self.origin)
-                        .map_err(|e| DataFusionError::Execution(format!("cubism_bucket_start: {e}")))?
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("cubism_bucket_start: {e}"))
+                        })?
                         .start
                         .unix_micros(),
                 ),
@@ -377,8 +383,14 @@ impl ScalarUDFImpl for XUnitCanonicalBytesUdf {
 fn xunit_identity_udfs(dict: SharedDictionary) -> (ScalarUDF, ScalarUDF) {
     let binary_arg = || Signature::exact(vec![DataType::Binary], Volatility::Immutable);
     (
-        ScalarUDF::from(XUnitContentIdUdf { dict: Arc::clone(&dict), signature: binary_arg() }),
-        ScalarUDF::from(XUnitCanonicalBytesUdf { dict, signature: binary_arg() }),
+        ScalarUDF::from(XUnitContentIdUdf {
+            dict: Arc::clone(&dict),
+            signature: binary_arg(),
+        }),
+        ScalarUDF::from(XUnitCanonicalBytesUdf {
+            dict,
+            signature: binary_arg(),
+        }),
     )
 }
 
@@ -396,7 +408,9 @@ fn rfc3339_micros(event_time: EventTime) -> Result<String> {
 }
 
 fn window_filter_sql(temporal: &TemporalSpec, window: Option<TimeRange>) -> Result<Option<String>> {
-    let Some(window) = window else { return Ok(None) };
+    let Some(window) = window else {
+        return Ok(None);
+    };
     let start = rfc3339_micros(window.start())?;
     let end = rfc3339_micros(window.end())?;
     Ok(Some(format!(
@@ -421,7 +435,12 @@ fn measure_sql(spec: &CubeSpec) -> Result<MeasureSql> {
     for (i, measure) in spec.measures.iter().enumerate() {
         let alias = format!("__m{i}");
         let out_col = measure_column_name(measure);
-        let input = || measure.input.as_ref().expect("validated: agg requires input");
+        let input = || {
+            measure
+                .input
+                .as_ref()
+                .expect("validated: agg requires input")
+        };
         match measure.agg {
             AggKind::Sum | AggKind::Min | AggKind::Max => {
                 let f = match measure.agg {
@@ -486,7 +505,12 @@ fn measure_sql(spec: &CubeSpec) -> Result<MeasureSql> {
     if agg_selects.is_empty() {
         return plan_err!("cube spec has no measures");
     }
-    Ok(MeasureSql { measure_selects, passthrough, agg_selects, final_cols })
+    Ok(MeasureSql {
+        measure_selects,
+        passthrough,
+        agg_selects,
+        final_cols,
+    })
 }
 
 /// Everything [`pipeline_ctes`] needs beyond `(temporal, source, window,
@@ -510,8 +534,12 @@ fn pipeline_ctes(
     null_policy: NullEventTimePolicy,
     columns: PipelineColumns<'_>,
 ) -> Result<String> {
-    let PipelineColumns { measure_selects, level_selects, level_args, measure_passthrough } =
-        columns;
+    let PipelineColumns {
+        measure_selects,
+        level_selects,
+        level_args,
+        measure_passthrough,
+    } = columns;
     let event_expr = &temporal.event_time;
     let window_clause = match window_filter_sql(temporal, window)? {
         Some(clause) => format!("\n  WHERE {clause}"),
@@ -526,10 +554,15 @@ fn pipeline_ctes(
         .chain(level_selects.iter().cloned())
         .chain(measure_selects.iter().cloned())
         .collect();
-    let bucketed_passthrough: String =
-        level_args.iter().chain(measure_passthrough).map(|a| format!(", {a}")).collect();
-    let exploded_passthrough: String =
-        measure_passthrough.iter().map(|a| format!(", {a}")).collect();
+    let bucketed_passthrough: String = level_args
+        .iter()
+        .chain(measure_passthrough)
+        .map(|a| format!(", {a}"))
+        .collect();
+    let exploded_passthrough: String = measure_passthrough
+        .iter()
+        .map(|a| format!(", {a}"))
+        .collect();
 
     Ok(format!(
         "__cubism_time AS (\n  SELECT {input}\n  FROM {source}{window_clause}\n),\n\
@@ -602,16 +635,26 @@ fn exploded_only_sql(
             measure_passthrough: &measures.passthrough,
         },
     )?;
-    Ok(format!("WITH {ctes}\nSELECT __bucket_start, __xunit_key FROM __cubism_exploded"))
+    Ok(format!(
+        "WITH {ctes}\nSELECT __bucket_start, __xunit_key FROM __cubism_exploded"
+    ))
 }
 
-async fn null_event_time_count(ctx: &SessionContext, temporal: &TemporalSpec, source: &str) -> Result<u64> {
-    let sql =
-        format!("SELECT COUNT(*) AS n FROM {source} WHERE {event} IS NULL", event = temporal.event_time);
+async fn null_event_time_count(
+    ctx: &SessionContext,
+    temporal: &TemporalSpec,
+    source: &str,
+) -> Result<u64> {
+    let sql = format!(
+        "SELECT COUNT(*) AS n FROM {source} WHERE {event} IS NULL",
+        event = temporal.event_time
+    );
     let batches = ctx.sql(&sql).await?.collect().await?;
     let mut total: i64 = 0;
     for batch in &batches {
-        let col = batch.column(0).as_primitive::<datafusion::arrow::datatypes::Int64Type>();
+        let col = batch
+            .column(0)
+            .as_primitive::<datafusion::arrow::datatypes::Int64Type>();
         for i in 0..col.len() {
             total += col.value(i);
         }
@@ -634,7 +677,7 @@ pub struct TemporalBuildMetadata {
     pub null_event_time_rows: u64,
     /// `None` when no `window` was requested — [`Coverage::requested`] needs
     /// a [`TimeRange`] to assess coverage against, and an unbounded build
-    /// has none. `Some` otherwise, computed by [`compute_coverage`]: a cheap
+    /// has none. `Some` otherwise, computed by `compute_coverage`: a cheap
     /// `MIN`/`MAX(bucket_start)` scan, *not* a per-bucket occupancy check.
     /// **`Exactness::Exact` means the observed data reaches both edges of
     /// the requested window — it is not a claim that every bucket in
@@ -684,7 +727,8 @@ pub async fn build_temporal(
     window_id: Option<WindowId>,
     null_policy: NullEventTimePolicy,
 ) -> Result<TemporalBuildOutput> {
-    spec.validate().map_err(|e| DataFusionError::Plan(e.to_string()))?;
+    spec.validate()
+        .map_err(|e| DataFusionError::Plan(e.to_string()))?;
     let temporal = temporal_spec(spec)?;
     let resolution = fixed_resolution(temporal)?;
 
@@ -763,7 +807,12 @@ pub async fn build_temporal(
         states,
         registry,
         dictionary: dict,
-        metadata: TemporalBuildMetadata { window, window_id, null_event_time_rows: null_count, coverage },
+        metadata: TemporalBuildMetadata {
+            window,
+            window_id,
+            null_event_time_rows: null_count,
+            coverage,
+        },
     })
 }
 
@@ -778,7 +827,10 @@ async fn compute_coverage(
 ) -> Result<Coverage> {
     let bounds = cached.clone().aggregate(
         vec![],
-        vec![min(col("bucket_start")).alias("min_bucket"), max(col("bucket_start")).alias("max_bucket")],
+        vec![
+            min(col("bucket_start")).alias("min_bucket"),
+            max(col("bucket_start")).alias("max_bucket"),
+        ],
     )?;
     let batches = bounds.collect().await?;
     let batch = &batches[0];
@@ -799,9 +851,12 @@ async fn compute_coverage(
     // *event time*, not bucket bounds). Clamping to `requested` keeps
     // `covered` from claiming coverage of time the filter guaranteed has
     // zero rows.
-    let observed_end_micros = max_col.value(0).checked_add(resolution.micros()).ok_or_else(|| {
-        DataFusionError::Execution("covered bucket end overflows i64 microseconds".into())
-    })?;
+    let observed_end_micros = max_col
+        .value(0)
+        .checked_add(resolution.micros())
+        .ok_or_else(|| {
+            DataFusionError::Execution("covered bucket end overflows i64 microseconds".into())
+        })?;
     let covered_start_micros = min_col.value(0).max(requested.start().unix_micros());
     let covered_end_micros = observed_end_micros.min(requested.end().unix_micros());
     let covered = TimeRange::new(
@@ -827,7 +882,11 @@ async fn compute_coverage(
         ))
     };
 
-    Ok(Coverage { requested, covered: vec![covered], exactness })
+    Ok(Coverage {
+        requested,
+        covered: vec![covered],
+        exactness,
+    })
 }
 
 /// Write a build's two tables to local Parquet fixtures (no Iceberg
@@ -840,8 +899,16 @@ pub async fn write_temporal_fixtures(
     registry_path: &str,
 ) -> Result<()> {
     let single_file = || DataFrameWriteOptions::new().with_single_file_output(true);
-    output.states.clone().write_parquet(states_path, single_file(), None).await?;
-    output.registry.clone().write_parquet(registry_path, single_file(), None).await?;
+    output
+        .states
+        .clone()
+        .write_parquet(states_path, single_file(), None)
+        .await?;
+    output
+        .registry
+        .clone()
+        .write_parquet(registry_path, single_file(), None)
+        .await?;
     Ok(())
 }
 
@@ -870,7 +937,9 @@ pub async fn explain_temporal_build(
     let output_rows: usize = states_batches.iter().map(|b| b.num_rows()).sum();
     let mut buckets = std::collections::BTreeSet::new();
     for batch in &states_batches {
-        let col = batch.column(0).as_primitive::<datafusion::arrow::datatypes::TimestampMicrosecondType>();
+        let col = batch
+            .column(0)
+            .as_primitive::<datafusion::arrow::datatypes::TimestampMicrosecondType>();
         for i in 0..col.len() {
             buckets.insert(col.value(i));
         }
@@ -884,8 +953,11 @@ pub async fn explain_temporal_build(
     let source_rows = scalar_count(ctx, &source_rows_sql).await?;
 
     let exploded_sql = exploded_only_sql(spec, source, window, null_policy)?;
-    let generated_xunits =
-        scalar_count(ctx, &format!("SELECT COUNT(*) AS n FROM ({exploded_sql}) AS t")).await?;
+    let generated_xunits = scalar_count(
+        ctx,
+        &format!("SELECT COUNT(*) AS n FROM ({exploded_sql}) AS t"),
+    )
+    .await?;
 
     Ok(TemporalBuildExplain {
         source_rows,
@@ -900,7 +972,9 @@ async fn scalar_count(ctx: &SessionContext, sql: &str) -> Result<usize> {
     let batches = ctx.sql(sql).await?.collect().await?;
     let mut total: i64 = 0;
     for batch in &batches {
-        let col = batch.column(0).as_primitive::<datafusion::arrow::datatypes::Int64Type>();
+        let col = batch
+            .column(0)
+            .as_primitive::<datafusion::arrow::datatypes::Int64Type>();
         for i in 0..col.len() {
             total += col.value(i);
         }
@@ -969,7 +1043,16 @@ temporal:
         let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(
             names,
-            vec!["bucket_start", "xunit_id", "total_v1", "events_v1", "mean_v1", "spread_v1", "p50_v1", "reach_v1"]
+            vec![
+                "bucket_start",
+                "xunit_id",
+                "total_v1",
+                "events_v1",
+                "mean_v1",
+                "spread_v1",
+                "p50_v1",
+                "reach_v1"
+            ]
         );
         let types: Vec<&DataType> = schema.fields().iter().map(|f| f.data_type()).collect();
         assert_eq!(
@@ -1009,7 +1092,11 @@ temporal:
         // top_k is already rejected at spec validation time for temporal
         // specs (see cubism-core's spec.rs); this asserts that contract
         // still holds rather than re-testing it here.
-        assert!(spec.unwrap_err().to_string().contains("top_k is not supported"));
+        assert!(
+            spec.unwrap_err()
+                .to_string()
+                .contains("top_k is not supported")
+        );
     }
 
     // -- end-to-end hand-computed cells --------------------------------------
@@ -1056,7 +1143,9 @@ includeGlobal: true
                     TimestampMicrosecondArray::from(vec![0i64, 1_000, HOUR_US, HOUR_US + 500])
                         .with_timezone("+00:00"),
                 ),
-                Arc::new(StringArray::from(vec!["mobile", "mobile", "desktop", "mobile"])),
+                Arc::new(StringArray::from(vec![
+                    "mobile", "mobile", "desktop", "mobile",
+                ])),
                 Arc::new(Int64Array::from(vec![10, 20, 40, 80])),
                 Arc::new(StringArray::from(vec!["u1", "u2", "u1", "u3"])),
             ],
@@ -1069,8 +1158,16 @@ includeGlobal: true
         let spec = CubeSpec::from_yaml(E2E_TEMPORAL_SPEC).unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", e2e_batch()).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
 
         // The DataFrame's actual Arrow schema must equal the declared
         // authority exactly — name, type, *and* nullability.
@@ -1098,7 +1195,11 @@ includeGlobal: true
         let mut cells: HashMap<(i64, [u8; 32]), Cell> = HashMap::new();
         for batch in &batches {
             let bucket = batch.column(0).as_primitive::<TimestampMicrosecondType>();
-            let ids = batch.column(1).as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
+            let ids = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
             let sum = batch.column(2).as_primitive::<Float64Type>();
             let count = batch.column(3).as_primitive::<Int64Type>();
             let avg_blob = batch.column(4).as_binary::<i32>();
@@ -1119,8 +1220,15 @@ includeGlobal: true
         }
         let mut sorted_order = order.clone();
         sorted_order.sort();
-        assert_eq!(order, sorted_order, "states must be sorted by (bucket_start, xunit_id)");
-        assert_eq!(cells.len(), 5, "bucket0: {{/G, mobile}}, bucket1: {{/G, mobile, desktop}}");
+        assert_eq!(
+            order, sorted_order,
+            "states must be sorted by (bucket_start, xunit_id)"
+        );
+        assert_eq!(
+            cells.len(),
+            5,
+            "bucket0: {{/G, mobile}}, bucket1: {{/G, mobile, desktop}}"
+        );
 
         let global_id = content_id_of("/G");
         let mobile_id = content_id_of("/device/device=mobile");
@@ -1128,16 +1236,32 @@ includeGlobal: true
 
         let (sum, count, avg, reach) = &cells[&(0, global_id)];
         assert_eq!((*sum, *count), (30.0, 2));
-        assert_eq!(cubism_core::AverageState::decode(avg).unwrap().present(), Some(15.0));
-        assert_eq!(cubism_core::KmvSketch::from_bytes(reach).unwrap().estimate(), 2.0);
+        assert_eq!(
+            cubism_core::AverageState::decode(avg).unwrap().present(),
+            Some(15.0)
+        );
+        assert_eq!(
+            cubism_core::KmvSketch::from_bytes(reach)
+                .unwrap()
+                .estimate(),
+            2.0
+        );
 
         let (sum, count, _, _) = &cells[&(0, mobile_id)];
         assert_eq!((*sum, *count), (30.0, 2));
 
         let (sum, count, avg, reach) = &cells[&(HOUR_US, global_id)];
         assert_eq!((*sum, *count), (120.0, 2));
-        assert_eq!(cubism_core::AverageState::decode(avg).unwrap().present(), Some(60.0));
-        assert_eq!(cubism_core::KmvSketch::from_bytes(reach).unwrap().estimate(), 2.0);
+        assert_eq!(
+            cubism_core::AverageState::decode(avg).unwrap().present(),
+            Some(60.0)
+        );
+        assert_eq!(
+            cubism_core::KmvSketch::from_bytes(reach)
+                .unwrap()
+                .estimate(),
+            2.0
+        );
 
         let (sum, count, _, _) = &cells[&(HOUR_US, desktop_id)];
         assert_eq!((*sum, *count), (40.0, 1));
@@ -1147,12 +1271,19 @@ includeGlobal: true
         let registry_batches = output.registry.collect().await.unwrap();
         let mut registry_ids: HashSet<[u8; 32]> = HashSet::new();
         for batch in &registry_batches {
-            let ids = batch.column(0).as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
             for i in 0..batch.num_rows() {
                 registry_ids.insert(ids.value(i).try_into().unwrap());
             }
         }
-        assert_eq!(registry_ids, HashSet::from([global_id, mobile_id, desktop_id]));
+        assert_eq!(
+            registry_ids,
+            HashSet::from([global_id, mobile_id, desktop_id])
+        );
     }
 
     #[tokio::test]
@@ -1162,16 +1293,32 @@ includeGlobal: true
         async fn run(spec: &CubeSpec) -> Vec<(i64, [u8; 32], i64)> {
             let ctx = SessionContext::new();
             ctx.register_batch("events", e2e_batch()).unwrap();
-            let output =
-                build_temporal(&ctx, spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+            let output = build_temporal(
+                &ctx,
+                spec,
+                "events",
+                None,
+                None,
+                NullEventTimePolicy::Reject,
+            )
+            .await
+            .unwrap();
             let batches = output.states.collect().await.unwrap();
             let mut out = Vec::new();
             for batch in &batches {
                 let bucket = batch.column(0).as_primitive::<TimestampMicrosecondType>();
-                let ids = batch.column(1).as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
+                let ids = batch
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .unwrap();
                 let count = batch.column(3).as_primitive::<Int64Type>();
                 for i in 0..batch.num_rows() {
-                    out.push((bucket.value(i), ids.value(i).try_into().unwrap(), count.value(i)));
+                    out.push((
+                        bucket.value(i),
+                        ids.value(i).try_into().unwrap(),
+                        count.value(i),
+                    ));
                 }
             }
             out
@@ -1187,8 +1334,16 @@ includeGlobal: true
         let spec = CubeSpec::from_yaml(E2E_TEMPORAL_SPEC).unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", e2e_batch()).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         assert!(output.metadata.coverage.is_none());
     }
 
@@ -1199,12 +1354,21 @@ includeGlobal: true
         ctx.register_batch("events", e2e_batch()).unwrap();
         // Fixture events span [0, HOUR_US + 500), i.e. buckets [0, HOUR_US)
         // and [HOUR_US, 2*HOUR_US) — request exactly that span.
-        let window =
-            TimeRange::new(EventTime::from_unix_micros(0), EventTime::from_unix_micros(2 * HOUR_US))
-                .unwrap();
-        let output = build_temporal(&ctx, &spec, "events", Some(window), None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let window = TimeRange::new(
+            EventTime::from_unix_micros(0),
+            EventTime::from_unix_micros(2 * HOUR_US),
+        )
+        .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            Some(window),
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let coverage = output.metadata.coverage.unwrap();
         assert_eq!(coverage.requested, window);
         assert_eq!(coverage.covered, vec![window]);
@@ -1222,14 +1386,23 @@ includeGlobal: true
             EventTime::from_unix_micros(3 * HOUR_US),
         )
         .unwrap();
-        let output = build_temporal(&ctx, &spec, "events", Some(window), None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            Some(window),
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let coverage = output.metadata.coverage.unwrap();
         assert_eq!(coverage.requested, window);
-        let expected_covered =
-            TimeRange::new(EventTime::from_unix_micros(0), EventTime::from_unix_micros(2 * HOUR_US))
-                .unwrap();
+        let expected_covered = TimeRange::new(
+            EventTime::from_unix_micros(0),
+            EventTime::from_unix_micros(2 * HOUR_US),
+        )
+        .unwrap();
         assert_eq!(coverage.covered, vec![expected_covered]);
         assert!(matches!(coverage.exactness, Exactness::Inexact(_)));
     }
@@ -1252,12 +1425,23 @@ includeGlobal: true
             EventTime::from_unix_micros(3 * HOUR_US / 2),
         )
         .unwrap();
-        let output = build_temporal(&ctx, &spec, "events", Some(window), None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            Some(window),
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let coverage = output.metadata.coverage.unwrap();
         let covered = coverage.covered[0];
-        assert_eq!(covered.end(), window.end(), "must not overclaim past the requested window's end");
+        assert_eq!(
+            covered.end(),
+            window.end(),
+            "must not overclaim past the requested window's end"
+        );
     }
 
     #[tokio::test]
@@ -1274,9 +1458,16 @@ includeGlobal: true
             EventTime::from_unix_micros(2 * HOUR_US),
         )
         .unwrap();
-        let output = build_temporal(&ctx, &spec, "events", Some(window), None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            Some(window),
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let coverage = output.metadata.coverage.unwrap();
         assert_eq!(coverage.covered, vec![window]);
         assert_eq!(coverage.exactness, Exactness::Exact);
@@ -1292,9 +1483,16 @@ includeGlobal: true
             EventTime::from_unix_micros(11 * HOUR_US),
         )
         .unwrap();
-        let output = build_temporal(&ctx, &spec, "events", Some(window), None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            Some(window),
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let coverage = output.metadata.coverage.unwrap();
         assert_eq!(coverage.covered, vec![]);
         assert!(matches!(coverage.exactness, Exactness::Inexact(_)));
@@ -1307,19 +1505,33 @@ includeGlobal: true
         let spec = CubeSpec::from_yaml(E2E_TEMPORAL_SPEC).unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", e2e_batch()).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
 
-        let dir = std::env::temp_dir()
-            .join(format!("cubism_temporal_fixture_test_{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!(
+            "cubism_temporal_fixture_test_{}",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let states_path = dir.join("registry_states.parquet");
         let registry_path = dir.join("xunit_registry.parquet");
 
-        write_temporal_fixtures(&output, states_path.to_str().unwrap(), registry_path.to_str().unwrap())
-            .await
-            .unwrap();
+        write_temporal_fixtures(
+            &output,
+            states_path.to_str().unwrap(),
+            registry_path.to_str().unwrap(),
+        )
+        .await
+        .unwrap();
 
         // `DataFrame::write_parquet` writes a directory of part files unless
         // single-file output is requested — this is the one thing a unit
@@ -1328,17 +1540,27 @@ includeGlobal: true
         assert!(
             states_path.is_file(),
             "expected a single states file, dir contents: {:?}",
-            std::fs::read_dir(&dir).unwrap().map(|e| e.unwrap().path()).collect::<Vec<_>>()
+            std::fs::read_dir(&dir)
+                .unwrap()
+                .map(|e| e.unwrap().path())
+                .collect::<Vec<_>>()
         );
         assert!(
             registry_path.is_file(),
             "expected a single registry file, dir contents: {:?}",
-            std::fs::read_dir(&dir).unwrap().map(|e| e.unwrap().path()).collect::<Vec<_>>()
+            std::fs::read_dir(&dir)
+                .unwrap()
+                .map(|e| e.unwrap().path())
+                .collect::<Vec<_>>()
         );
 
         let read_ctx = SessionContext::new();
         read_ctx
-            .register_parquet("states_readback", states_path.to_str().unwrap(), ParquetReadOptions::default())
+            .register_parquet(
+                "states_readback",
+                states_path.to_str().unwrap(),
+                ParquetReadOptions::default(),
+            )
             .await
             .unwrap();
         read_ctx
@@ -1349,9 +1571,12 @@ includeGlobal: true
             )
             .await
             .unwrap();
-        let states_rows = scalar_count(&read_ctx, "SELECT COUNT(*) AS n FROM states_readback").await.unwrap();
-        let registry_rows =
-            scalar_count(&read_ctx, "SELECT COUNT(*) AS n FROM registry_readback").await.unwrap();
+        let states_rows = scalar_count(&read_ctx, "SELECT COUNT(*) AS n FROM states_readback")
+            .await
+            .unwrap();
+        let registry_rows = scalar_count(&read_ctx, "SELECT COUNT(*) AS n FROM registry_readback")
+            .await
+            .unwrap();
         assert_eq!(states_rows, 5);
         assert_eq!(registry_rows, 3);
 
@@ -1399,7 +1624,15 @@ includeGlobal: true
 
         let ctx_reject = SessionContext::new();
         ctx_reject.register_batch("events", batch.clone()).unwrap();
-        let result = build_temporal(&ctx_reject, &spec, "events", None, None, NullEventTimePolicy::Reject).await;
+        let result = build_temporal(
+            &ctx_reject,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await;
         let err = match result {
             Err(e) => e,
             Ok(_) => panic!("expected the build to reject a null event time"),
@@ -1419,7 +1652,14 @@ includeGlobal: true
         .await
         .unwrap();
         assert_eq!(output.metadata.null_event_time_rows, 1);
-        let rows: usize = output.states.collect().await.unwrap().iter().map(|b| b.num_rows()).sum();
+        let rows: usize = output
+            .states
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
         // bucket0={mobile}: {/G, mobile}; bucket1={mobile}: {/G, mobile} = 4.
         assert_eq!(rows, 4);
     }
@@ -1454,7 +1694,8 @@ temporal:
             schema,
             vec![
                 Arc::new(
-                    TimestampMicrosecondArray::from(vec![HOUR_US - 1, HOUR_US]).with_timezone("+00:00"),
+                    TimestampMicrosecondArray::from(vec![HOUR_US - 1, HOUR_US])
+                        .with_timezone("+00:00"),
                 ),
                 Arc::new(StringArray::from(vec!["mobile", "mobile"])),
             ],
@@ -1462,8 +1703,16 @@ temporal:
         .unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", batch).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let batches = output.states.collect().await.unwrap();
         let mut buckets: Vec<i64> = Vec::new();
         for batch in &batches {
@@ -1502,24 +1751,31 @@ temporal:
         let event_seconds = -90 * 60_i64;
         let event_at_90m_seconds = 90 * 60_i64;
 
-        async fn run_for_unit(
-            spec: &CubeSpec,
-            column: ArrayRef,
-        ) -> Vec<i64> {
+        async fn run_for_unit(spec: &CubeSpec, column: ArrayRef) -> Vec<i64> {
             let schema = Arc::new(Schema::new(vec![
                 Field::new("occurred_at", column.data_type().clone(), false),
                 Field::new("device", DataType::Utf8, false),
             ]));
             let batch = RecordBatch::try_new(
                 schema,
-                vec![column, Arc::new(StringArray::from(vec!["mobile", "mobile"]))],
+                vec![
+                    column,
+                    Arc::new(StringArray::from(vec!["mobile", "mobile"])),
+                ],
             )
             .unwrap();
             let ctx = SessionContext::new();
             ctx.register_batch("events", batch).unwrap();
-            let output = build_temporal(&ctx, spec, "events", None, None, NullEventTimePolicy::Reject)
-                .await
-                .unwrap();
+            let output = build_temporal(
+                &ctx,
+                spec,
+                "events",
+                None,
+                None,
+                NullEventTimePolicy::Reject,
+            )
+            .await
+            .unwrap();
             let batches = output.states.collect().await.unwrap();
             let mut buckets: Vec<i64> = Vec::new();
             for batch in &batches {
@@ -1542,8 +1798,11 @@ temporal:
         assert_eq!(run_for_unit(&spec, seconds).await, expected, "seconds");
 
         let millis: ArrayRef = Arc::new(
-            TimestampMillisecondArray::from(vec![event_seconds * 1_000, event_at_90m_seconds * 1_000])
-                .with_timezone("+00:00"),
+            TimestampMillisecondArray::from(vec![
+                event_seconds * 1_000,
+                event_at_90m_seconds * 1_000,
+            ])
+            .with_timezone("+00:00"),
         );
         assert_eq!(run_for_unit(&spec, millis).await, expected, "milliseconds");
 
@@ -1588,7 +1847,10 @@ temporal:
         ]));
         let batch = RecordBatch::try_new(
             schema,
-            vec![Arc::new(Int64Array::from(vec![0i64])), Arc::new(StringArray::from(vec!["mobile"]))],
+            vec![
+                Arc::new(Int64Array::from(vec![0i64])),
+                Arc::new(StringArray::from(vec!["mobile"])),
+            ],
         )
         .unwrap();
         let ctx = SessionContext::new();
@@ -1596,13 +1858,23 @@ temporal:
         // `build_temporal` only builds the (lazy) logical plan — DataFusion
         // doesn't call a UDF's `invoke_with_args` until physical execution,
         // so the type mismatch only surfaces on `.collect()`.
-        let output = build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let result = output.states.collect().await;
         let err = match result {
             Err(e) => e,
-            Ok(batches) => panic!("expected rejection, got {} batches: {batches:?}", batches.len()),
+            Ok(batches) => panic!(
+                "expected rejection, got {} batches: {batches:?}",
+                batches.len()
+            ),
         };
         assert!(err.to_string().contains("requires a TIMESTAMP column"));
     }
@@ -1670,7 +1942,9 @@ includeGlobal: true
         let static_spec = CubeSpec::from_yaml(STATIC).unwrap();
         let ctx1 = SessionContext::new();
         ctx1.register_batch("events", make_batch()).unwrap();
-        let (df, _dict) = crate::build_cube(&ctx1, &static_spec, "events").await.unwrap();
+        let (df, _dict) = crate::build_cube(&ctx1, &static_spec, "events")
+            .await
+            .unwrap();
         let static_batches = df.collect().await.unwrap();
         let mut static_ids: HashSet<[u8; 32]> = HashSet::new();
         for batch in &static_batches {
@@ -1683,13 +1957,24 @@ includeGlobal: true
         let temporal_spec = CubeSpec::from_yaml(TEMPORAL).unwrap();
         let ctx2 = SessionContext::new();
         ctx2.register_batch("events", make_batch()).unwrap();
-        let output = build_temporal(&ctx2, &temporal_spec, "events", None, None, NullEventTimePolicy::Reject)
-            .await
-            .unwrap();
+        let output = build_temporal(
+            &ctx2,
+            &temporal_spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let registry_batches = output.registry.collect().await.unwrap();
         let mut temporal_ids: HashSet<[u8; 32]> = HashSet::new();
         for batch in &registry_batches {
-            let ids = batch.column(0).as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
             for i in 0..batch.num_rows() {
                 temporal_ids.insert(ids.value(i).try_into().unwrap());
             }
@@ -1743,8 +2028,11 @@ includeGlobal: true
             let per_dimension: Vec<Vec<cubism_core::YPath>> = dims
                 .iter()
                 .map(|d| {
-                    let value =
-                        if d.name == "device" { devices[i].clone() } else { regions[i].clone() };
+                    let value = if d.name == "device" {
+                        devices[i].clone()
+                    } else {
+                        regions[i].clone()
+                    };
                     d.ypaths_for_values(&[Some(value)])
                 })
                 .collect();
@@ -1788,10 +2076,24 @@ includeGlobal: true
 
         let ctx = SessionContext::new();
         ctx.register_batch("events", batch).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
-        let produced_rows: usize =
-            output.states.collect().await.unwrap().iter().map(|b| b.num_rows()).sum();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
+        let produced_rows: usize = output
+            .states
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
         assert_eq!(produced_rows, oracle.len());
     }
 
@@ -1861,15 +2163,23 @@ includeGlobal: true
                     TimestampMicrosecondArray::from(rows.iter().map(|r| r.0).collect::<Vec<_>>())
                         .with_timezone("+00:00"),
                 ),
-                Arc::new(StringArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>())),
-                Arc::new(StringArray::from(rows.iter().map(|r| r.2).collect::<Vec<_>>())),
-                Arc::new(Int64Array::from(rows.iter().map(|r| r.3).collect::<Vec<_>>())),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.3).collect::<Vec<_>>(),
+                )),
             ],
         )
         .unwrap()
     }
 
-    async fn pt_static_totals(rows: &[(i64, &str, &str, i64)]) -> HashMap<[u8; 32], (f64, i64, f64)> {
+    async fn pt_static_totals(
+        rows: &[(i64, &str, &str, i64)],
+    ) -> HashMap<[u8; 32], (f64, i64, f64)> {
         let spec = CubeSpec::from_yaml(PT_STATIC_SPEC).unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", pt_batch(rows)).unwrap();
@@ -1897,12 +2207,24 @@ includeGlobal: true
         let spec = CubeSpec::from_yaml(PT_TEMPORAL_SPEC).unwrap();
         let ctx = SessionContext::new();
         ctx.register_batch("events", pt_batch(rows)).unwrap();
-        let output =
-            build_temporal(&ctx, &spec, "events", None, None, NullEventTimePolicy::Reject).await.unwrap();
+        let output = build_temporal(
+            &ctx,
+            &spec,
+            "events",
+            None,
+            None,
+            NullEventTimePolicy::Reject,
+        )
+        .await
+        .unwrap();
         let batches = output.states.collect().await.unwrap();
         let mut out: HashMap<[u8; 32], (f64, i64, AverageState)> = HashMap::new();
         for batch in &batches {
-            let ids = batch.column(1).as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
+            let ids = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .unwrap();
             let total = batch.column(2).as_primitive::<Float64Type>();
             let events = batch.column(3).as_primitive::<Int64Type>();
             let mean_blob = batch.column(4).as_binary::<i32>();

--- a/crates/cubism-datafusion/src/udaf.rs
+++ b/crates/cubism-datafusion/src/udaf.rs
@@ -11,7 +11,7 @@
 //! `state` / `merge_batch` / `evaluate`), which maps 1:1 onto the mergeable
 //! sketch algebra in `cubism_core::sketch`.
 
-use cubism_core::sketch::kmv::{hash_value, KmvSketch, DEFAULT_SKETCH_SIZE};
+use cubism_core::sketch::kmv::{DEFAULT_SKETCH_SIZE, KmvSketch, hash_value};
 use cubism_core::sketch::sample::DEFAULT_SAMPLE_CAPACITY;
 use cubism_core::sketch::topk::DEFAULT_TOPK_CAPACITY;
 use cubism_core::sketch::{Centroid, ExemplarSample, TopK};
@@ -19,7 +19,7 @@ use datafusion::arrow::array::{
     Array, ArrayRef, AsArray, BinaryBuilder, BooleanArray, Float64Builder,
 };
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
-use datafusion::common::{exec_err, Result, ScalarValue};
+use datafusion::common::{Result, ScalarValue, exec_err};
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion::logical_expr::{
     Accumulator, AggregateUDF, AggregateUDFImpl, ColumnarValue, EmitTo, GroupsAccumulator,
@@ -47,7 +47,9 @@ impl AggregateUDFImpl for KmvSketchUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(KmvAccumulator { sketch: KmvSketch::new(self.k) }))
+        Ok(Box::new(KmvAccumulator {
+            sketch: KmvSketch::new(self.k),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
@@ -66,7 +68,9 @@ impl AggregateUDFImpl for KmvSketchUdaf {
         &self,
         _args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
-        Ok(Box::new(SketchGroupsAccumulator::new(KmvKernel { k: self.k })))
+        Ok(Box::new(SketchGroupsAccumulator::new(KmvKernel {
+            k: self.k,
+        })))
     }
 }
 
@@ -183,11 +187,17 @@ impl AggregateUDFImpl for TopKUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(TopKAccumulator { topk: TopK::new(self.capacity) }))
+        Ok(Box::new(TopKAccumulator {
+            topk: TopK::new(self.capacity),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[topk]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[topk]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 
     fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
@@ -198,7 +208,9 @@ impl AggregateUDFImpl for TopKUdaf {
         &self,
         _args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
-        Ok(Box::new(SketchGroupsAccumulator::new(TopKKernel { capacity: self.capacity })))
+        Ok(Box::new(SketchGroupsAccumulator::new(TopKKernel {
+            capacity: self.capacity,
+        })))
     }
 }
 
@@ -266,11 +278,17 @@ impl AggregateUDFImpl for SampleUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(SampleAccumulator { sample: ExemplarSample::new(self.capacity) }))
+        Ok(Box::new(SampleAccumulator {
+            sample: ExemplarSample::new(self.capacity),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[sample]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[sample]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 
     fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
@@ -281,7 +299,9 @@ impl AggregateUDFImpl for SampleUdaf {
         &self,
         _args: AccumulatorArgs,
     ) -> Result<Box<dyn GroupsAccumulator>> {
-        Ok(Box::new(SketchGroupsAccumulator::new(SampleKernel { capacity: self.capacity })))
+        Ok(Box::new(SketchGroupsAccumulator::new(SampleKernel {
+            capacity: self.capacity,
+        })))
     }
 }
 
@@ -344,11 +364,17 @@ impl AggregateUDFImpl for CentroidUdaf {
     }
 
     fn accumulator(&self, _args: AccumulatorArgs) -> Result<Box<dyn Accumulator>> {
-        Ok(Box::new(CentroidAccumulator { centroid: Centroid::new() }))
+        Ok(Box::new(CentroidAccumulator {
+            centroid: Centroid::new(),
+        }))
     }
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>> {
-        Ok(vec![Arc::new(Field::new(format!("{}[centroid]", args.name), DataType::Binary, true))])
+        Ok(vec![Arc::new(Field::new(
+            format!("{}[centroid]", args.name),
+            DataType::Binary,
+            true,
+        ))])
     }
 
     fn groups_accumulator_supported(&self, _args: AccumulatorArgs) -> bool {
@@ -403,8 +429,15 @@ impl Accumulator for CentroidAccumulator {
                     continue;
                 }
                 let (start, end) = (offsets[i] as usize, offsets[i + 1] as usize);
-                let vector: Vec<f64> =
-                    (start..end).map(|j| if floats.is_null(j) { 0.0 } else { floats.value(j) }).collect();
+                let vector: Vec<f64> = (start..end)
+                    .map(|j| {
+                        if floats.is_null(j) {
+                            0.0
+                        } else {
+                            floats.value(j)
+                        }
+                    })
+                    .collect();
                 self.centroid.add(&vector).map_err(to_df_err)?;
             }
         }
@@ -474,9 +507,7 @@ impl ScalarUDFImpl for BlobPresenterUdf {
                 continue;
             }
             let rendered = match self.kind {
-                PresenterKind::TopKJson => {
-                    TopK::from_bytes(blobs.value(i)).map(|t| t.to_json())
-                }
+                PresenterKind::TopKJson => TopK::from_bytes(blobs.value(i)).map(|t| t.to_json()),
                 PresenterKind::SampleJson => {
                     ExemplarSample::from_bytes(blobs.value(i)).map(|s| s.to_json())
                 }
@@ -505,7 +536,11 @@ impl ScalarUDFImpl for CentroidMeanUdf {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::List(Arc::new(Field::new("item", DataType::Float64, true))))
+        Ok(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Float64,
+            true,
+        ))))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -572,7 +607,10 @@ struct SketchGroupsAccumulator<K: SketchKernel> {
 
 impl<K: SketchKernel> SketchGroupsAccumulator<K> {
     fn new(kernel: K) -> Self {
-        SketchGroupsAccumulator { kernel, groups: Vec::new() }
+        SketchGroupsAccumulator {
+            kernel,
+            groups: Vec::new(),
+        }
     }
 
     fn resize(&mut self, total_num_groups: usize) {
@@ -598,7 +636,8 @@ impl<K: SketchKernel> GroupsAccumulator for SketchGroupsAccumulator<K> {
         total_num_groups: usize,
     ) -> Result<()> {
         self.resize(total_num_groups);
-        self.kernel.update_rows(&mut self.groups, values, group_indices, opt_filter)
+        self.kernel
+            .update_rows(&mut self.groups, values, group_indices, opt_filter)
     }
 
     fn evaluate(&mut self, emit_to: EmitTo) -> Result<ArrayRef> {
@@ -633,8 +672,7 @@ impl<K: SketchKernel> GroupsAccumulator for SketchGroupsAccumulator<K> {
     }
 
     fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.groups.iter().map(K::mem_size).sum::<usize>()
+        std::mem::size_of::<Self>() + self.groups.iter().map(K::mem_size).sum::<usize>()
     }
 }
 
@@ -812,7 +850,13 @@ impl SketchKernel for CentroidKernel {
                 groups[group].add(&flat[start..end]).map_err(to_df_err)?;
             } else {
                 let vector: Vec<f64> = (start..end)
-                    .map(|j| if floats.is_null(j) { 0.0 } else { floats.value(j) })
+                    .map(|j| {
+                        if floats.is_null(j) {
+                            0.0
+                        } else {
+                            floats.value(j)
+                        }
+                    })
                     .collect();
                 groups[group].add(&vector).map_err(to_df_err)?;
             }
@@ -821,7 +865,9 @@ impl SketchKernel for CentroidKernel {
     }
 
     fn merge_blob(sketch: &mut Centroid, blob: &[u8]) -> Result<()> {
-        *sketch = sketch.merge(&Centroid::from_bytes(blob).map_err(to_df_err)?).map_err(to_df_err)?;
+        *sketch = sketch
+            .merge(&Centroid::from_bytes(blob).map_err(to_df_err)?)
+            .map_err(to_df_err)?;
         Ok(())
     }
 
@@ -842,7 +888,9 @@ fn to_df_err(e: cubism_core::CubismError) -> datafusion::common::DataFusionError
 
 fn iter_blobs(array: &ArrayRef) -> impl Iterator<Item = &[u8]> {
     let arr = array.as_binary::<i32>();
-    (0..arr.len()).filter(|&i| !arr.is_null(i)).map(move |i| arr.value(i))
+    (0..arr.len())
+        .filter(|&i| !arr.is_null(i))
+        .map(move |i| arr.value(i))
 }
 
 /// All sketch UDFs. They are stateless (unlike the per-build XUnit UDFs) and
@@ -866,10 +914,14 @@ pub fn sketch_udfs() -> (Vec<AggregateUDF>, Vec<ScalarUDF>) {
                 capacity: DEFAULT_SAMPLE_CAPACITY,
                 signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
             }),
-            AggregateUDF::from(CentroidUdaf { signature: Signature::any(1, Volatility::Immutable) }),
+            AggregateUDF::from(CentroidUdaf {
+                signature: Signature::any(1, Volatility::Immutable),
+            }),
         ],
         vec![
-            ScalarUDF::from(KmvEstimateUdf { signature: binary_arg() }),
+            ScalarUDF::from(KmvEstimateUdf {
+                signature: binary_arg(),
+            }),
             ScalarUDF::from(BlobPresenterUdf {
                 name: "cubism_topk_json",
                 signature: binary_arg(),
@@ -880,7 +932,9 @@ pub fn sketch_udfs() -> (Vec<AggregateUDF>, Vec<ScalarUDF>) {
                 signature: binary_arg(),
                 kind: PresenterKind::SampleJson,
             }),
-            ScalarUDF::from(CentroidMeanUdf { signature: binary_arg() }),
+            ScalarUDF::from(CentroidMeanUdf {
+                signature: binary_arg(),
+            }),
         ],
     )
 }

--- a/crates/cubism-datafusion/src/udf.rs
+++ b/crates/cubism-datafusion/src/udf.rs
@@ -9,12 +9,12 @@
 //! `cubism_xunit_str(key) -> Utf8` decodes a binary key to the canonical
 //! string form at the present boundary.
 
-use cubism_core::encoding::{decode_xunit, encode_xunit, XUnitDictionary};
+use cubism_core::encoding::{XUnitDictionary, decode_xunit, encode_xunit};
 use cubism_core::lattice::generate_xunits;
 use cubism_core::{CubeSpec, FilterRule};
 use datafusion::arrow::array::{Array, AsArray, BinaryBuilder, ListBuilder, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field};
-use datafusion::common::{exec_err, Result};
+use datafusion::common::{Result, exec_err};
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
@@ -45,7 +45,13 @@ impl ExplodeShape {
             .sorted_dimensions()
             .iter()
             .map(|d| {
-                (d.name.clone(), d.effective_levels().iter().map(|l| l.name.clone()).collect())
+                (
+                    d.name.clone(),
+                    d.effective_levels()
+                        .iter()
+                        .map(|l| l.name.clone())
+                        .collect(),
+                )
             })
             .collect();
         ExplodeShape {
@@ -81,7 +87,11 @@ type KeyMemo = Arc<Mutex<Arc<HashMap<u64, MemoBucket>>>>;
 /// rows just take the compute path; results stay identical.
 const MEMO_MAX_BUCKETS: usize = 1 << 18;
 
-fn tuple_matches(stored: &[Option<String>], cols: &[&datafusion::arrow::array::StringArray], row: usize) -> bool {
+fn tuple_matches(
+    stored: &[Option<String>],
+    cols: &[&datafusion::arrow::array::StringArray],
+    row: usize,
+) -> bool {
     stored.iter().zip(cols).all(|(s, col)| match s {
         None => col.is_null(row),
         Some(v) => !col.is_null(row) && col.value(row) == v,
@@ -143,8 +153,11 @@ impl XUnitKeysUdf {
             per_dimension.push(ypaths);
         }
 
-        let xunits =
-            generate_xunits(&per_dimension, &self.shape.filter_rules, self.shape.include_global);
+        let xunits = generate_xunits(
+            &per_dimension,
+            &self.shape.filter_rules,
+            self.shape.include_global,
+        );
         let keys = xunits.iter().map(|x| encode_xunit(x, dict)).collect();
         if dict.len() > self.shape.max_dictionary_entries {
             return exec_err!(
@@ -171,7 +184,11 @@ impl ScalarUDFImpl for XUnitKeysUdf {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::List(Arc::new(Field::new("item", DataType::Binary, true))))
+        Ok(DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::Binary,
+            true,
+        ))))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -231,7 +248,10 @@ impl ScalarUDFImpl for XUnitKeysUdf {
                             .iter()
                             .map(|c| (!c.is_null(row)).then(|| c.value(row).to_string()))
                             .collect();
-                        batch_misses.entry(memo_key).or_default().push((tuple, Arc::clone(&keys)));
+                        batch_misses
+                            .entry(memo_key)
+                            .or_default()
+                            .push((tuple, Arc::clone(&keys)));
                     }
                     keys
                 }

--- a/crates/cubism-datafusion/tests/iceberg_bridge.rs
+++ b/crates/cubism-datafusion/tests/iceberg_bridge.rs
@@ -49,7 +49,9 @@ use tempfile::TempDir;
 const CUBE_ID: &str = "web_analytics";
 
 fn micros(timestamp: &str) -> i64 {
-    DateTime::parse_from_rfc3339(timestamp).unwrap().timestamp_micros()
+    DateTime::parse_from_rfc3339(timestamp)
+        .unwrap()
+        .timestamp_micros()
 }
 
 /// The real `XUnitContentId` a selector resolves to — same two calls
@@ -87,14 +89,20 @@ fn states_schema() -> ArrowSchema {
 fn states_batch(rows: &[(&str, [u8; 32], i64, f64)]) -> RecordBatch {
     use datafusion::arrow::array::{FixedSizeBinaryArray, TimestampMicrosecondArray};
 
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _, _)| *x)).unwrap();
     let count = Int64Array::from_iter_values(rows.iter().map(|(_, _, c, _)| *c));
     let sum = Float64Array::from_iter_values(rows.iter().map(|(_, _, _, s)| *s));
     RecordBatch::try_new(
         Arc::new(states_schema()),
-        vec![Arc::new(bucket_start), Arc::new(xunit_id), Arc::new(count), Arc::new(sum)],
+        vec![
+            Arc::new(bucket_start),
+            Arc::new(xunit_id),
+            Arc::new(count),
+            Arc::new(sum),
+        ],
     )
     .unwrap()
 }
@@ -146,9 +154,13 @@ fn registry_batch(rows: &[([u8; 32], &[u8])]) -> RecordBatch {
 #[tokio::test]
 async fn record_batch_from_read_window_round_trips_through_a_df54_session_context() {
     let warehouse = TempDir::new().unwrap();
-    let config = CatalogConfig::Memory { warehouse: warehouse.path().to_path_buf() };
+    let config = CatalogConfig::Memory {
+        warehouse: warehouse.path().to_path_buf(),
+    };
     let catalog = open_catalog(&config).await.unwrap();
-    let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &states_schema()).await.unwrap();
+    let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &states_schema())
+        .await
+        .unwrap();
     let publications = PublicationStore::in_memory();
 
     let window_id = WindowId::new("2026-08-14").unwrap();
@@ -157,7 +169,10 @@ async fn record_batch_from_read_window_round_trips_through_a_df54_session_contex
         ("2026-08-14T00:10:00Z", [1u8; 32], 3, 9.0),
         ("2026-08-14T00:20:00Z", [2u8; 32], 5, 11.0),
     ])];
-    let registry = vec![registry_batch(&[([1u8; 32], b"US/mobile"), ([2u8; 32], b"EU/desktop")])];
+    let registry = vec![registry_batch(&[
+        ([1u8; 32], b"US/mobile"),
+        ([2u8; 32], b"EU/desktop"),
+    ])];
 
     let expected_rows: u64 = states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
     let claim = publications
@@ -169,19 +184,29 @@ async fn record_batch_from_read_window_round_trips_through_a_df54_session_contex
     let result = AggregateWriter::append_window(
         catalog.as_ref(),
         &temporal_table,
-        AppendWindow { window_id: &window_id, revision, run_id: "run-1", states: &states, registry: &registry },
+        AppendWindow {
+            window_id: &window_id,
+            revision,
+            run_id: "run-1",
+            states: &states,
+            registry: &registry,
+        },
     )
     .await
     .unwrap();
-    publications.record_append("run-1", result.snapshot_id).await.unwrap();
+    publications
+        .record_append("run-1", result.snapshot_id)
+        .await
+        .unwrap();
     // Publish before reading: `read_window` rejects an appended-but-unpublished
     // revision with `UnpublishedWindow` (`cubism-iceberg/tests/phase3.rs`
     // proves the same), which is not the seam this milestone is testing.
     publications.publish("run-1", None).await.unwrap();
 
-    let batches = AggregateReader::read_window(catalog.as_ref(), &temporal_table, &publications, &window_id)
-        .await
-        .unwrap();
+    let batches =
+        AggregateReader::read_window(catalog.as_ref(), &temporal_table, &publications, &window_id)
+            .await
+            .unwrap();
 
     // No `iceberg-datafusion` anywhere above or below this line — just a
     // `Vec<arrow_array::RecordBatch>` handed to a DF54 `SessionContext`.
@@ -190,7 +215,10 @@ async fn record_batch_from_read_window_round_trips_through_a_df54_session_contex
     let collected = df.collect().await.unwrap();
 
     let total_rows: usize = collected.iter().map(RecordBatch::num_rows).sum();
-    assert_eq!(total_rows, 2, "both appended rows should round-trip through the SessionContext");
+    assert_eq!(
+        total_rows, 2,
+        "both appended rows should round-trip through the SessionContext"
+    );
 
     // Beyond the row-count check above (which a schema-only round-trip
     // could satisfy without decoding any column), sum `count_v1` to prove
@@ -209,7 +237,11 @@ async fn record_batch_from_read_window_round_trips_through_a_df54_session_contex
                 .sum::<i64>()
         })
         .sum();
-    assert_eq!(total_count_v1, 3 + 5, "count_v1 values must decode correctly, not just round-trip a row count");
+    assert_eq!(
+        total_count_v1,
+        3 + 5,
+        "count_v1 values must decode correctly, not just round-trip a row count"
+    );
 }
 
 /// Milestone 10 (`docs/TIMESERIES_ROADMAP.md`): the real wiring the module
@@ -230,9 +262,13 @@ async fn record_batch_from_read_window_round_trips_through_a_df54_session_contex
 #[tokio::test]
 async fn coverage_plan_resolves_real_publication_state_across_two_windows() {
     let warehouse = TempDir::new().unwrap();
-    let config = CatalogConfig::Memory { warehouse: warehouse.path().to_path_buf() };
+    let config = CatalogConfig::Memory {
+        warehouse: warehouse.path().to_path_buf(),
+    };
     let catalog = open_catalog(&config).await.unwrap();
-    let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &states_schema()).await.unwrap();
+    let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &states_schema())
+        .await
+        .unwrap();
     let publications = PublicationStore::in_memory();
 
     let day = FixedResolution::from_micros(86_400_000_000).unwrap();
@@ -263,7 +299,11 @@ async fn coverage_plan_resolves_real_publication_state_across_two_windows() {
     )
     .unwrap();
     let plan = ResolutionPlan::new(&query, &spec).unwrap();
-    assert_eq!(plan.segments.len(), 1, "two contiguous day buckets must stay one aligned segment");
+    assert_eq!(
+        plan.segments.len(),
+        1,
+        "two contiguous day buckets must stay one aligned segment"
+    );
     assert!(plan.segments[0].aligned);
 
     let w1 = WindowId::new("2026-08-13").unwrap();
@@ -275,16 +315,28 @@ async fn coverage_plan_resolves_real_publication_state_across_two_windows() {
     let states = vec![states_batch(&[("2026-08-13T12:00:00Z", [1u8; 32], 3, 9.0)])];
     let registry = vec![registry_batch(&[([1u8; 32], b"US/mobile")])];
     let expected_rows: u64 = states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
-    let claim = publications.claim_run(CUBE_ID, &w1, "run-1", revision, expected_rows).await.unwrap();
+    let claim = publications
+        .claim_run(CUBE_ID, &w1, "run-1", revision, expected_rows)
+        .await
+        .unwrap();
     assert!(matches!(claim, ClaimResult::New(_)));
     let result = AggregateWriter::append_window(
         catalog.as_ref(),
         &temporal_table,
-        AppendWindow { window_id: &w1, revision, run_id: "run-1", states: &states, registry: &registry },
+        AppendWindow {
+            window_id: &w1,
+            revision,
+            run_id: "run-1",
+            states: &states,
+            registry: &registry,
+        },
     )
     .await
     .unwrap();
-    publications.record_append("run-1", result.snapshot_id).await.unwrap();
+    publications
+        .record_append("run-1", result.snapshot_id)
+        .await
+        .unwrap();
     publications.publish("run-1", None).await.unwrap();
 
     // w2 is never claimed, appended, or published: `current` must resolve

--- a/crates/cubism-iceberg/src/config.rs
+++ b/crates/cubism-iceberg/src/config.rs
@@ -38,7 +38,10 @@ pub enum CatalogConfig {
     /// open the same `catalog_db` concurrently. `catalog_db` is created
     /// (`CREATE TABLE IF NOT EXISTS`, via SQLite's `mode=rwc` URI query
     /// param) if it does not already exist.
-    Sqlite { warehouse: PathBuf, catalog_db: PathBuf },
+    Sqlite {
+        warehouse: PathBuf,
+        catalog_db: PathBuf,
+    },
 }
 
 /// Open the catalog described by `config`.
@@ -56,7 +59,10 @@ pub async fn open_catalog(config: &CatalogConfig) -> Result<Arc<dyn Catalog>> {
                 .map_err(CubismIcebergError::Iceberg)?;
             Ok(Arc::new(catalog))
         }
-        CatalogConfig::Sqlite { warehouse, catalog_db } => {
+        CatalogConfig::Sqlite {
+            warehouse,
+            catalog_db,
+        } => {
             let warehouse_path = warehouse.to_string_lossy().into_owned();
             let db_uri = format!("sqlite:{}?mode=rwc", catalog_db.to_string_lossy());
             let catalog = SqlCatalogBuilder::default()
@@ -66,7 +72,10 @@ pub async fn open_catalog(config: &CatalogConfig) -> Result<Arc<dyn Catalog>> {
                     HashMap::from([
                         (SQL_CATALOG_PROP_URI.to_string(), db_uri),
                         (SQL_CATALOG_PROP_WAREHOUSE.to_string(), warehouse_path),
-                        (SQL_CATALOG_PROP_BIND_STYLE.to_string(), SqlBindStyle::QMark.to_string()),
+                        (
+                            SQL_CATALOG_PROP_BIND_STYLE.to_string(),
+                            SqlBindStyle::QMark.to_string(),
+                        ),
                     ]),
                 )
                 .await

--- a/crates/cubism-iceberg/src/control.rs
+++ b/crates/cubism-iceberg/src/control.rs
@@ -167,8 +167,14 @@ impl InMemoryStore {
         // only on the fresh-insert path (an existing run keeps its original
         // observation), inside the same mutex critical section as the
         // insert itself.
-        let observed_generation = state.window_generations.get(&window_key).copied().unwrap_or(0);
-        state.claim_generations.insert(run_id.to_string(), observed_generation);
+        let observed_generation = state
+            .window_generations
+            .get(&window_key)
+            .copied()
+            .unwrap_or(0);
+        state
+            .claim_generations
+            .insert(run_id.to_string(), observed_generation);
         Ok(ClaimResult::New(claimed))
     }
 
@@ -181,18 +187,24 @@ impl InMemoryStore {
             .ok_or_else(|| unknown_run(run_id))?;
 
         let appended = match current {
-            RunState::Claimed { window_key, revision, expected_rows } => RunState::Appended {
+            RunState::Claimed {
+                window_key,
+                revision,
+                expected_rows,
+            } => RunState::Appended {
                 window_key,
                 revision,
                 expected_rows,
                 aggregate_snapshot_id,
             },
-            RunState::Appended { aggregate_snapshot_id: existing, .. }
-            | RunState::Published { aggregate_snapshot_id: existing, .. }
-                if existing == aggregate_snapshot_id =>
-            {
-                current
+            RunState::Appended {
+                aggregate_snapshot_id: existing,
+                ..
             }
+            | RunState::Published {
+                aggregate_snapshot_id: existing,
+                ..
+            } if existing == aggregate_snapshot_id => current,
             other => {
                 return Err(CubismIcebergError::RunConflict {
                     run_id: run_id.to_string(),
@@ -207,7 +219,11 @@ impl InMemoryStore {
         Ok(appended)
     }
 
-    fn publish(&self, run_id: &str, expected_current: Option<WindowRevision>) -> Result<Publication> {
+    fn publish(
+        &self,
+        run_id: &str,
+        expected_current: Option<WindowRevision>,
+    ) -> Result<Publication> {
         let mut state = self.state.lock().expect("control store mutex poisoned");
         let run = state
             .runs
@@ -216,19 +232,36 @@ impl InMemoryStore {
             .ok_or_else(|| unknown_run(run_id))?;
 
         let (window_key, revision, expected_rows, aggregate_snapshot_id) = match run {
-            RunState::Appended { window_key, revision, expected_rows, aggregate_snapshot_id }
-            | RunState::Published { window_key, revision, expected_rows, aggregate_snapshot_id } => {
-                (window_key, revision, expected_rows, aggregate_snapshot_id)
+            RunState::Appended {
+                window_key,
+                revision,
+                expected_rows,
+                aggregate_snapshot_id,
             }
+            | RunState::Published {
+                window_key,
+                revision,
+                expected_rows,
+                aggregate_snapshot_id,
+            } => (window_key, revision, expected_rows, aggregate_snapshot_id),
             RunState::Claimed { .. } => {
-                return Err(CubismIcebergError::RunNotAppended { run_id: run_id.to_string() });
+                return Err(CubismIcebergError::RunNotAppended {
+                    run_id: run_id.to_string(),
+                });
             }
         };
 
-        let key = WindowKey { cube_id: window_key.0.clone(), window_id: window_key.1.clone() };
+        let key = WindowKey {
+            cube_id: window_key.0.clone(),
+            window_id: window_key.1.clone(),
+        };
         let actual = state.publications.get(&key).map(|p| p.revision);
         if actual == Some(revision) {
-            return Ok(state.publications.get(&key).expect("publication just observed").clone());
+            return Ok(state
+                .publications
+                .get(&key)
+                .expect("publication just observed")
+                .clone());
         }
         if actual != expected_current {
             return Err(CubismIcebergError::StaleRevision {
@@ -238,7 +271,11 @@ impl InMemoryStore {
             });
         }
 
-        let publication = Publication { revision, run_id: run_id.to_string(), aggregate_snapshot_id };
+        let publication = Publication {
+            revision,
+            run_id: run_id.to_string(),
+            aggregate_snapshot_id,
+        };
         state.publications.insert(key.clone(), publication.clone());
         // Bump only here — a *changing* write (first publication, later
         // correction, or rollback republish). The idempotent early-return
@@ -248,7 +285,12 @@ impl InMemoryStore {
         *state.window_generations.entry(key).or_insert(0) += 1;
         state.runs.insert(
             run_id.to_string(),
-            RunState::Published { window_key, revision, expected_rows, aggregate_snapshot_id },
+            RunState::Published {
+                window_key,
+                revision,
+                expected_rows,
+                aggregate_snapshot_id,
+            },
         );
         Ok(publication)
     }
@@ -257,7 +299,11 @@ impl InMemoryStore {
     /// incremented by every changing publish (see [`State`]'s field doc).
     fn publication_generation(&self, cube_id: &str, window_id: &WindowId) -> u64 {
         let state = self.state.lock().expect("control store mutex poisoned");
-        state.window_generations.get(&WindowKey::new(cube_id, window_id)).copied().unwrap_or(0)
+        state
+            .window_generations
+            .get(&WindowKey::new(cube_id, window_id))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// The window generation this run observed at its first-ever claim, or
@@ -330,14 +376,24 @@ impl PublicationStore {
         expected_rows: u64,
     ) -> Result<ClaimResult> {
         match self {
-            Self::InMemory(store) => store.claim_run(cube_id, window_id, run_id, revision, expected_rows),
-            Self::Sqlite(store) => store.claim_run(cube_id, window_id, run_id, revision, expected_rows).await,
+            Self::InMemory(store) => {
+                store.claim_run(cube_id, window_id, run_id, revision, expected_rows)
+            }
+            Self::Sqlite(store) => {
+                store
+                    .claim_run(cube_id, window_id, run_id, revision, expected_rows)
+                    .await
+            }
         }
     }
 
     /// Record the atomic Iceberg snapshot produced by an append. A retry
     /// with the same snapshot ID is harmless.
-    pub async fn record_append(&self, run_id: &str, aggregate_snapshot_id: i64) -> Result<RunState> {
+    pub async fn record_append(
+        &self,
+        run_id: &str,
+        aggregate_snapshot_id: i64,
+    ) -> Result<RunState> {
         match self {
             Self::InMemory(store) => store.record_append(run_id, aggregate_snapshot_id),
             Self::Sqlite(store) => store.record_append(run_id, aggregate_snapshot_id).await,
@@ -347,7 +403,11 @@ impl PublicationStore {
     /// Atomically change the current revision for a window, iff the caller
     /// observed the expected current revision (CAS). `None` means "the
     /// window has never been published."
-    pub async fn publish(&self, run_id: &str, expected_current: Option<WindowRevision>) -> Result<Publication> {
+    pub async fn publish(
+        &self,
+        run_id: &str,
+        expected_current: Option<WindowRevision>,
+    ) -> Result<Publication> {
         match self {
             Self::InMemory(store) => store.publish(run_id, expected_current),
             Self::Sqlite(store) => store.publish(run_id, expected_current).await,
@@ -357,7 +417,11 @@ impl PublicationStore {
     /// The currently published revision for a window, if any. `Ok(None)`
     /// means unpublished; `Err` means the durable backend itself failed
     /// (e.g. a SQLite I/O error) — callers must not conflate the two.
-    pub async fn current(&self, cube_id: &str, window_id: &WindowId) -> Result<Option<WindowRevision>> {
+    pub async fn current(
+        &self,
+        cube_id: &str,
+        window_id: &WindowId,
+    ) -> Result<Option<WindowRevision>> {
         match self {
             Self::InMemory(store) => Ok(store.current(cube_id, window_id)),
             Self::Sqlite(store) => store.current(cube_id, window_id).await,
@@ -419,8 +483,14 @@ mod tests {
     async fn deterministic_retry_returns_existing_run_state() {
         let store = PublicationStore::in_memory();
         let w = window("2026-08-12");
-        let first = store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
-        let retry = store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
+        let first = store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
+        let retry = store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
         assert!(matches!(first, ClaimResult::New(_)));
         assert!(matches!(retry, ClaimResult::Existing(_)));
         assert_eq!(first.state(), retry.state());
@@ -430,8 +500,14 @@ mod tests {
     async fn claiming_the_same_run_id_with_different_inputs_is_rejected() {
         let store = PublicationStore::in_memory();
         let w = window("2026-08-12");
-        store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
-        let error = store.claim_run("cube", &w, "run-1", revision(2), 10).await.unwrap_err();
+        store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
+        let error = store
+            .claim_run("cube", &w, "run-1", revision(2), 10)
+            .await
+            .unwrap_err();
         assert!(matches!(error, CubismIcebergError::RunConflict { .. }));
     }
 
@@ -439,7 +515,10 @@ mod tests {
     async fn publish_requires_the_run_to_be_appended_first() {
         let store = PublicationStore::in_memory();
         let w = window("2026-08-12");
-        store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
         let error = store.publish("run-1", None).await.unwrap_err();
         assert!(matches!(error, CubismIcebergError::RunNotAppended { .. }));
     }
@@ -449,20 +528,33 @@ mod tests {
         let store = PublicationStore::in_memory();
         let w = window("2026-08-12");
 
-        store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
         store.record_append("run-1", 101).await.unwrap();
         store.publish("run-1", None).await.unwrap();
 
-        store.claim_run("cube", &w, "run-2", revision(2), 10).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-2", revision(2), 10)
+            .await
+            .unwrap();
         store.record_append("run-2", 102).await.unwrap();
-        store.claim_run("cube", &w, "run-3", revision(3), 10).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-3", revision(3), 10)
+            .await
+            .unwrap();
         store.record_append("run-3", 103).await.unwrap();
 
         store.publish("run-2", Some(revision(1))).await.unwrap();
         let error = store.publish("run-3", Some(revision(1))).await.unwrap_err();
         assert!(matches!(
             error,
-            CubismIcebergError::StaleRevision { expected: Some(1), actual: Some(2), .. }
+            CubismIcebergError::StaleRevision {
+                expected: Some(1),
+                actual: Some(2),
+                ..
+            }
         ));
         assert_eq!(store.current("cube", &w).await.unwrap(), Some(revision(2)));
     }
@@ -471,7 +563,10 @@ mod tests {
     async fn a_republish_of_the_already_current_revision_is_a_harmless_no_op() {
         let store = PublicationStore::in_memory();
         let w = window("2026-08-12");
-        store.claim_run("cube", &w, "run-1", revision(1), 10).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-1", revision(1), 10)
+            .await
+            .unwrap();
         store.record_append("run-1", 101).await.unwrap();
         let first = store.publish("run-1", None).await.unwrap();
         let second = store.publish("run-1", None).await.unwrap();

--- a/crates/cubism-iceberg/src/coordinator.rs
+++ b/crates/cubism-iceberg/src/coordinator.rs
@@ -149,9 +149,17 @@ use crate::writer::{AggregateWriter, AppendWindow};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReconciliationRecord {
     NotStarted,
-    AwaitingAppend { revision: WindowRevision },
-    AwaitingPublish { revision: WindowRevision, aggregate_snapshot_id: i64 },
-    Published { revision: WindowRevision, aggregate_snapshot_id: i64 },
+    AwaitingAppend {
+        revision: WindowRevision,
+    },
+    AwaitingPublish {
+        revision: WindowRevision,
+        aggregate_snapshot_id: i64,
+    },
+    Published {
+        revision: WindowRevision,
+        aggregate_snapshot_id: i64,
+    },
 }
 
 impl ReconciliationRecord {
@@ -161,13 +169,25 @@ impl ReconciliationRecord {
     pub fn classify(run_state: Option<&RunState>) -> Self {
         match run_state {
             None => Self::NotStarted,
-            Some(RunState::Claimed { revision, .. }) => Self::AwaitingAppend { revision: *revision },
-            Some(RunState::Appended { revision, aggregate_snapshot_id, .. }) => {
-                Self::AwaitingPublish { revision: *revision, aggregate_snapshot_id: *aggregate_snapshot_id }
-            }
-            Some(RunState::Published { revision, aggregate_snapshot_id, .. }) => {
-                Self::Published { revision: *revision, aggregate_snapshot_id: *aggregate_snapshot_id }
-            }
+            Some(RunState::Claimed { revision, .. }) => Self::AwaitingAppend {
+                revision: *revision,
+            },
+            Some(RunState::Appended {
+                revision,
+                aggregate_snapshot_id,
+                ..
+            }) => Self::AwaitingPublish {
+                revision: *revision,
+                aggregate_snapshot_id: *aggregate_snapshot_id,
+            },
+            Some(RunState::Published {
+                revision,
+                aggregate_snapshot_id,
+                ..
+            }) => Self::Published {
+                revision: *revision,
+                aggregate_snapshot_id: *aggregate_snapshot_id,
+            },
         }
     }
 }
@@ -238,11 +258,18 @@ impl RunInspection {
         let revision_status = match &record {
             ReconciliationRecord::Published { revision, .. } => {
                 let current = publications.current(cube_id, window_id).await?;
-                Some(if current == Some(*revision) { RevisionStatus::Current } else { RevisionStatus::NotCurrent })
+                Some(if current == Some(*revision) {
+                    RevisionStatus::Current
+                } else {
+                    RevisionStatus::NotCurrent
+                })
             }
             _ => None,
         };
-        Ok(Self { record, revision_status })
+        Ok(Self {
+            record,
+            revision_status,
+        })
     }
 }
 
@@ -307,10 +334,16 @@ impl CorrectionCoordinator {
     ) -> Result<Publication> {
         let plan = CorrectionPlan::select(request.kinds);
         if plan.strategy() == CorrectionStrategy::AdditiveShortcut {
-            return Err(CubismIcebergError::UnsupportedCorrectionStrategy(plan.strategy()));
+            return Err(CubismIcebergError::UnsupportedCorrectionStrategy(
+                plan.strategy(),
+            ));
         }
 
-        let expected_rows: u64 = request.states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
+        let expected_rows: u64 = request
+            .states
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>() as u64;
         let claim = publications
             .claim_run(
                 &temporal_table.cube_id,
@@ -361,7 +394,9 @@ impl CorrectionCoordinator {
                     result.snapshot_id
                 }
             };
-            publications.record_append(request.run_id, snapshot_id).await?;
+            publications
+                .record_append(request.run_id, snapshot_id)
+                .await?;
         }
 
         // #20: a `Published` `RunState` alone does not prove this run's
@@ -385,7 +420,9 @@ impl CorrectionCoordinator {
         // shape against a run that never got that far needs a different
         // mechanism, below.
         if let ReconciliationRecord::Published { revision, .. } = record {
-            let current = publications.current(&temporal_table.cube_id, request.window_id).await?;
+            let current = publications
+                .current(&temporal_table.cube_id, request.window_id)
+                .await?;
             if current != Some(revision) {
                 return Err(CubismIcebergError::RunNoLongerCurrent {
                     run_id: request.run_id.to_string(),
@@ -425,12 +462,16 @@ impl CorrectionCoordinator {
         // -same-value slipping between them reopens a narrow race — the
         // same exposure class the plain CAS already has.
         if !matches!(record, ReconciliationRecord::Published { .. })
-            && let Some(observed_generation) = publications.run_observed_generation(request.run_id).await?
+            && let Some(observed_generation) =
+                publications.run_observed_generation(request.run_id).await?
         {
-            let current_generation =
-                publications.publication_generation(&temporal_table.cube_id, request.window_id).await?;
+            let current_generation = publications
+                .publication_generation(&temporal_table.cube_id, request.window_id)
+                .await?;
             if current_generation != observed_generation {
-                let current = publications.current(&temporal_table.cube_id, request.window_id).await?;
+                let current = publications
+                    .current(&temporal_table.cube_id, request.window_id)
+                    .await?;
                 return Err(CubismIcebergError::WindowChangedSinceClaim {
                     run_id: request.run_id.to_string(),
                     window_id: request.window_id.as_str().to_string(),
@@ -441,7 +482,9 @@ impl CorrectionCoordinator {
             }
         }
 
-        publications.publish(request.run_id, Some(request.observed_current)).await
+        publications
+            .publish(request.run_id, Some(request.observed_current))
+            .await
     }
 }
 
@@ -459,12 +502,21 @@ mod tests {
 
     #[test]
     fn classify_maps_every_run_state_stage_to_its_reconciliation_record() {
-        assert_eq!(ReconciliationRecord::classify(None), ReconciliationRecord::NotStarted);
+        assert_eq!(
+            ReconciliationRecord::classify(None),
+            ReconciliationRecord::NotStarted
+        );
 
-        let claimed = RunState::Claimed { window_key: window_key(), revision: revision(2), expected_rows: 3 };
+        let claimed = RunState::Claimed {
+            window_key: window_key(),
+            revision: revision(2),
+            expected_rows: 3,
+        };
         assert_eq!(
             ReconciliationRecord::classify(Some(&claimed)),
-            ReconciliationRecord::AwaitingAppend { revision: revision(2) }
+            ReconciliationRecord::AwaitingAppend {
+                revision: revision(2)
+            }
         );
 
         let appended = RunState::Appended {
@@ -475,7 +527,10 @@ mod tests {
         };
         assert_eq!(
             ReconciliationRecord::classify(Some(&appended)),
-            ReconciliationRecord::AwaitingPublish { revision: revision(2), aggregate_snapshot_id: 101 }
+            ReconciliationRecord::AwaitingPublish {
+                revision: revision(2),
+                aggregate_snapshot_id: 101
+            }
         );
 
         let published = RunState::Published {
@@ -486,7 +541,10 @@ mod tests {
         };
         assert_eq!(
             ReconciliationRecord::classify(Some(&published)),
-            ReconciliationRecord::Published { revision: revision(2), aggregate_snapshot_id: 101 }
+            ReconciliationRecord::Published {
+                revision: revision(2),
+                aggregate_snapshot_id: 101
+            }
         );
     }
 
@@ -506,15 +564,31 @@ mod tests {
         let store = PublicationStore::in_memory();
         let w = WindowId::new("2026-08-12").unwrap();
 
-        store.claim_run("cube", &w, "run-1", revision(1), 1).await.unwrap();
-        let claimed = RunInspection::inspect(&store, "cube", &w, "run-1").await.unwrap();
-        assert_eq!(claimed.record, ReconciliationRecord::AwaitingAppend { revision: revision(1) });
-        assert_eq!(claimed.revision_status, None, "no revision to compare against `current` before publish");
+        store
+            .claim_run("cube", &w, "run-1", revision(1), 1)
+            .await
+            .unwrap();
+        let claimed = RunInspection::inspect(&store, "cube", &w, "run-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            claimed.record,
+            ReconciliationRecord::AwaitingAppend {
+                revision: revision(1)
+            }
+        );
+        assert_eq!(
+            claimed.revision_status, None,
+            "no revision to compare against `current` before publish"
+        );
 
         store.record_append("run-1", 101).await.unwrap();
         store.publish("run-1", None).await.unwrap();
 
-        store.claim_run("cube", &w, "run-2", revision(2), 2).await.unwrap();
+        store
+            .claim_run("cube", &w, "run-2", revision(2), 2)
+            .await
+            .unwrap();
         store.record_append("run-2", 102).await.unwrap();
         store.publish("run-2", Some(revision(1))).await.unwrap();
 
@@ -523,17 +597,27 @@ mod tests {
         // `docs/TIMESERIES_PHASE_13_HANDOFF.md`.
         store.publish("run-1", Some(revision(2))).await.unwrap();
 
-        let run1 = RunInspection::inspect(&store, "cube", &w, "run-1").await.unwrap();
+        let run1 = RunInspection::inspect(&store, "cube", &w, "run-1")
+            .await
+            .unwrap();
         assert_eq!(
             run1.record,
-            ReconciliationRecord::Published { revision: revision(1), aggregate_snapshot_id: 101 }
+            ReconciliationRecord::Published {
+                revision: revision(1),
+                aggregate_snapshot_id: 101
+            }
         );
         assert_eq!(run1.revision_status, Some(RevisionStatus::Current));
 
-        let run2 = RunInspection::inspect(&store, "cube", &w, "run-2").await.unwrap();
+        let run2 = RunInspection::inspect(&store, "cube", &w, "run-2")
+            .await
+            .unwrap();
         assert_eq!(
             run2.record,
-            ReconciliationRecord::Published { revision: revision(2), aggregate_snapshot_id: 102 }
+            ReconciliationRecord::Published {
+                revision: revision(2),
+                aggregate_snapshot_id: 102
+            }
         );
         assert_eq!(
             run2.revision_status,

--- a/crates/cubism-iceberg/src/durable_control.rs
+++ b/crates/cubism-iceberg/src/durable_control.rs
@@ -109,7 +109,9 @@ use std::time::Duration;
 use cubism_core::temporal::{WindowId, WindowRevision};
 use futures::future::BoxFuture;
 use sqlx::Row;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteConnection, SqlitePool, SqlitePoolOptions, SqliteRow};
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteConnection, SqlitePool, SqlitePoolOptions, SqliteRow,
+};
 
 use crate::control::{ClaimResult, Publication, RunState};
 use crate::error::{CubismIcebergError, Result};
@@ -139,7 +141,10 @@ impl SqliteStore {
         // behind one physical SQLite connection, so this handle never
         // races itself; a second handle/process still arbitrates through
         // SQLite's own file locking (see the module doc comment).
-        let pool = SqlitePoolOptions::new().max_connections(1).connect_with(options).await?;
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await?;
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS control_runs (
@@ -191,9 +196,11 @@ impl SqliteStore {
                 .await?;
         }
         if !sqlite_column_exists(&pool, "control_publications", "generation").await? {
-            sqlx::query("ALTER TABLE control_publications ADD COLUMN generation INTEGER NOT NULL DEFAULT 0")
-                .execute(&pool)
-                .await?;
+            sqlx::query(
+                "ALTER TABLE control_publications ADD COLUMN generation INTEGER NOT NULL DEFAULT 0",
+            )
+            .execute(&pool)
+            .await?;
         }
 
         Ok(Self { pool })
@@ -278,7 +285,11 @@ impl SqliteStore {
         .await
     }
 
-    pub async fn record_append(&self, run_id: &str, aggregate_snapshot_id: i64) -> Result<RunState> {
+    pub async fn record_append(
+        &self,
+        run_id: &str,
+        aggregate_snapshot_id: i64,
+    ) -> Result<RunState> {
         let run_id = run_id.to_string();
 
         self.with_immediate_tx(move |conn| {
@@ -305,12 +316,14 @@ impl SqliteStore {
                 }
 
                 match &state {
-                    RunState::Appended { aggregate_snapshot_id: existing, .. }
-                    | RunState::Published { aggregate_snapshot_id: existing, .. }
-                        if *existing == aggregate_snapshot_id =>
-                    {
-                        Ok(state)
+                    RunState::Appended {
+                        aggregate_snapshot_id: existing,
+                        ..
                     }
+                    | RunState::Published {
+                        aggregate_snapshot_id: existing,
+                        ..
+                    } if *existing == aggregate_snapshot_id => Ok(state),
                     other => Err(CubismIcebergError::RunConflict {
                         run_id,
                         window_id: state_window_key(other).1,
@@ -323,7 +336,11 @@ impl SqliteStore {
         .await
     }
 
-    pub async fn publish(&self, run_id: &str, expected_current: Option<WindowRevision>) -> Result<Publication> {
+    pub async fn publish(
+        &self,
+        run_id: &str,
+        expected_current: Option<WindowRevision>,
+    ) -> Result<Publication> {
         let run_id = run_id.to_string();
 
         self.with_immediate_tx(move |conn| {
@@ -416,13 +433,24 @@ impl SqliteStore {
         .await
     }
 
-    pub async fn current(&self, cube_id: &str, window_id: &WindowId) -> Result<Option<WindowRevision>> {
-        let row = sqlx::query("SELECT revision FROM control_publications WHERE cube_id = ? AND window_id = ?")
-            .bind(cube_id)
-            .bind(window_id.as_str())
-            .fetch_optional(&self.pool)
-            .await?;
-        row.map(|row| Ok(WindowRevision::new(row.try_get::<i64, _>("revision")? as u64)?)).transpose()
+    pub async fn current(
+        &self,
+        cube_id: &str,
+        window_id: &WindowId,
+    ) -> Result<Option<WindowRevision>> {
+        let row = sqlx::query(
+            "SELECT revision FROM control_publications WHERE cube_id = ? AND window_id = ?",
+        )
+        .bind(cube_id)
+        .bind(window_id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(|row| {
+            Ok(WindowRevision::new(
+                row.try_get::<i64, _>("revision")? as u64
+            )?)
+        })
+        .transpose()
     }
 
     pub async fn run_state(&self, run_id: &str) -> Result<Option<RunState>> {
@@ -440,12 +468,17 @@ impl SqliteStore {
     /// bumped by every changing publish — see
     /// [`crate::control::PublicationStore::publication_generation`]).
     pub async fn publication_generation(&self, cube_id: &str, window_id: &WindowId) -> Result<u64> {
-        let row = sqlx::query("SELECT generation FROM control_publications WHERE cube_id = ? AND window_id = ?")
-            .bind(cube_id)
-            .bind(window_id.as_str())
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(row.map(|row| row.try_get::<i64, _>("generation")).transpose()?.unwrap_or(0) as u64)
+        let row = sqlx::query(
+            "SELECT generation FROM control_publications WHERE cube_id = ? AND window_id = ?",
+        )
+        .bind(cube_id)
+        .bind(window_id.as_str())
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row
+            .map(|row| row.try_get::<i64, _>("generation"))
+            .transpose()?
+            .unwrap_or(0) as u64)
     }
 
     /// The window generation a run observed at its first-ever claim.
@@ -455,8 +488,10 @@ impl SqliteStore {
     /// and fall through unprotected, not as a refusal (refusing would
     /// permanently break crash recovery across an upgrade).
     pub async fn run_observed_generation(&self, run_id: &str) -> Result<Option<u64>> {
-        let row =
-            sqlx::query("SELECT observed_generation FROM control_runs WHERE run_id = ?").bind(run_id).fetch_optional(&self.pool).await?;
+        let row = sqlx::query("SELECT observed_generation FROM control_runs WHERE run_id = ?")
+            .bind(run_id)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(row
             .map(|row| row.try_get::<Option<i64>, _>("observed_generation"))
             .transpose()?
@@ -559,7 +594,11 @@ async fn sqlite_column_exists(pool: &SqlitePool, table: &str, column: &str) -> R
     let rows = sqlx::query(&format!("SELECT name FROM pragma_table_info('{table}')"))
         .fetch_all(pool)
         .await?;
-    Ok(rows.iter().any(|row| row.try_get::<String, _>("name").map(|name| name == column).unwrap_or(false)))
+    Ok(rows.iter().any(|row| {
+        row.try_get::<String, _>("name")
+            .map(|name| name == column)
+            .unwrap_or(false)
+    }))
 }
 
 async fn fetch_run_row(conn: &mut SqliteConnection, run_id: &str) -> Result<Option<SqliteRow>> {
@@ -587,7 +626,11 @@ fn row_to_run_state(row: &SqliteRow) -> Result<RunState> {
     let corrupt = |detail: &str| CubismIcebergError::CorruptControlStore(detail.to_string());
 
     Ok(match status.as_str() {
-        "claimed" => RunState::Claimed { window_key, revision, expected_rows },
+        "claimed" => RunState::Claimed {
+            window_key,
+            revision,
+            expected_rows,
+        },
         "appended" => RunState::Appended {
             window_key,
             revision,

--- a/crates/cubism-iceberg/src/error.rs
+++ b/crates/cubism-iceberg/src/error.rs
@@ -44,7 +44,9 @@ pub enum CubismIcebergError {
     #[error("catalog kind is not implemented in this deployment: {0}")]
     UnsupportedCatalog(String),
 
-    #[error("run '{run_id}' was already claimed with different inputs (window {window_id}, revision {revision}, expected_rows {expected_rows})")]
+    #[error(
+        "run '{run_id}' was already claimed with different inputs (window {window_id}, revision {revision}, expected_rows {expected_rows})"
+    )]
     RunConflict {
         run_id: String,
         window_id: String,

--- a/crates/cubism-iceberg/src/lib.rs
+++ b/crates/cubism-iceberg/src/lib.rs
@@ -23,7 +23,9 @@ pub mod writer;
 
 pub use config::CatalogConfig;
 pub use control::{ClaimResult, Publication, PublicationStore, RunState};
-pub use coordinator::{CorrectionCoordinator, CorrectionRequest, ReconciliationRecord, RevisionStatus, RunInspection};
+pub use coordinator::{
+    CorrectionCoordinator, CorrectionRequest, ReconciliationRecord, RevisionStatus, RunInspection,
+};
 pub use correction::{CorrectionPlan, CorrectionStrategy};
 pub use error::CubismIcebergError;
 pub use reader::AggregateReader;

--- a/crates/cubism-iceberg/src/reader.rs
+++ b/crates/cubism-iceberg/src/reader.rs
@@ -65,7 +65,10 @@ impl AggregateReader {
             .build()
             .map_err(CubismIcebergError::Iceberg)?;
         let stream = scan.to_arrow().await.map_err(CubismIcebergError::Iceberg)?;
-        stream.try_collect().await.map_err(CubismIcebergError::Iceberg)
+        stream
+            .try_collect()
+            .await
+            .map_err(CubismIcebergError::Iceberg)
     }
 
     /// Whether a states row exists for exactly `(window_id, revision,

--- a/crates/cubism-iceberg/src/schema.rs
+++ b/crates/cubism-iceberg/src/schema.rs
@@ -104,7 +104,10 @@ pub fn xunit_registry_iceberg_schema() -> Result<IcebergSchema> {
         .map_err(CubismIcebergError::Iceberg)
 }
 
-fn arrow_type_to_iceberg_primitive(field_name: &str, data_type: &DataType) -> Result<PrimitiveType> {
+fn arrow_type_to_iceberg_primitive(
+    field_name: &str,
+    data_type: &DataType,
+) -> Result<PrimitiveType> {
     match data_type {
         DataType::Timestamp(TimeUnit::Microsecond, Some(tz)) if tz.as_ref() == "+00:00" => {
             Ok(PrimitiveType::Timestamptz)
@@ -115,7 +118,9 @@ fn arrow_type_to_iceberg_primitive(field_name: &str, data_type: &DataType) -> Re
         DataType::Int64 => Ok(PrimitiveType::Long),
         other => Err(CubismIcebergError::Iceberg(iceberg::Error::new(
             iceberg::ErrorKind::FeatureUnsupported,
-            format!("column '{field_name}' has unsupported Arrow type {other:?} for an Iceberg states table"),
+            format!(
+                "column '{field_name}' has unsupported Arrow type {other:?} for an Iceberg states table"
+            ),
         ))),
     }
 }

--- a/crates/cubism-iceberg/src/table.rs
+++ b/crates/cubism-iceberg/src/table.rs
@@ -6,7 +6,9 @@ use iceberg::table::Table;
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 
 use crate::error::Result;
-use crate::schema::{states_iceberg_schema, states_partition_spec, states_sort_order, xunit_registry_iceberg_schema};
+use crate::schema::{
+    states_iceberg_schema, states_partition_spec, states_sort_order, xunit_registry_iceberg_schema,
+};
 
 /// The two Iceberg tables backing one cube's temporal aggregates: the
 /// day-partitioned `states` table (Phase 2's `temporal_state_schema()`
@@ -77,5 +79,7 @@ impl TemporalTable {
 }
 
 pub fn current_snapshot_id(metadata: &TableMetadata) -> Option<i64> {
-    metadata.current_snapshot().map(|snapshot| snapshot.snapshot_id())
+    metadata
+        .current_snapshot()
+        .map(|snapshot| snapshot.snapshot_id())
 }

--- a/crates/cubism-iceberg/src/writer.rs
+++ b/crates/cubism-iceberg/src/writer.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use arrow_array::{Array, Date32Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use cubism_core::temporal::{WindowId, WindowRevision};
+use iceberg::Catalog;
 use iceberg::arrow::FieldMatchMode;
 use iceberg::spec::{DataFile, DataFileFormat, Literal, PartitionKey, Struct, Transform};
 use iceberg::table::Table;
@@ -18,12 +19,11 @@ use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::partitioning::PartitioningWriter;
 use iceberg::writer::partitioning::clustered_writer::ClusteredWriter;
 use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
-use iceberg::Catalog;
 use parquet::file::properties::WriterProperties;
 
 use crate::error::{CubismIcebergError, Result};
 use crate::schema::{REVISION_COLUMN, RUN_ID_COLUMN, WINDOW_ID_COLUMN};
-use crate::table::{current_snapshot_id, TemporalTable};
+use crate::table::{TemporalTable, current_snapshot_id};
 
 /// Result of one successful `append_window` commit. `snapshot_id` is the
 /// **exact** committed states-table snapshot ID, read back off the `Table`
@@ -79,10 +79,17 @@ impl AggregateWriter {
         temporal_table: &TemporalTable,
         window: AppendWindow<'_>,
     ) -> Result<CommitResult> {
-        let AppendWindow { window_id, revision, run_id, states, registry } = window;
+        let AppendWindow {
+            window_id,
+            revision,
+            run_id,
+            states,
+            registry,
+        } = window;
 
         let registry_table = temporal_table.registry_table(catalog).await?;
-        let registry_files = write_unpartitioned(&registry_table, run_id, "registry", registry).await?;
+        let registry_files =
+            write_unpartitioned(&registry_table, run_id, "registry", registry).await?;
         assert_unique_paths(registry_files.iter().map(DataFile::file_path))?;
         let registry_file_count = registry_files.len();
         if !registry_files.is_empty() {
@@ -91,21 +98,25 @@ impl AggregateWriter {
 
         let augmented_states: Vec<RecordBatch> = states
             .iter()
-            .map(|batch| augment_states_batch(batch, window_id.as_str(), revision.get() as i64, run_id))
+            .map(|batch| {
+                augment_states_batch(batch, window_id.as_str(), revision.get() as i64, run_id)
+            })
             .collect::<Result<_>>()?;
 
         let states_table = temporal_table.states_table(catalog).await?;
-        let states_files = write_states_partitioned(&states_table, run_id, &augmented_states).await?;
+        let states_files =
+            write_states_partitioned(&states_table, run_id, &augmented_states).await?;
         assert_unique_paths(states_files.iter().map(DataFile::file_path))?;
 
         let row_count: u64 = states_files.iter().map(DataFile::record_count).sum();
         let states_file_count = states_files.len();
         let committed = commit_append(catalog, &states_table, states_files).await?;
-        let snapshot_id = current_snapshot_id(committed.metadata())
-            .ok_or_else(|| CubismIcebergError::Iceberg(iceberg::Error::new(
+        let snapshot_id = current_snapshot_id(committed.metadata()).ok_or_else(|| {
+            CubismIcebergError::Iceberg(iceberg::Error::new(
                 iceberg::ErrorKind::Unexpected,
                 "states table has no current snapshot immediately after a successful commit",
-            )))?;
+            ))
+        })?;
 
         Ok(CommitResult {
             snapshot_id,
@@ -133,11 +144,17 @@ fn assert_unique_paths<'a>(paths: impl Iterator<Item = &'a str>) -> Result<()> {
     Ok(())
 }
 
-async fn commit_append(catalog: &dyn Catalog, table: &Table, files: Vec<DataFile>) -> Result<Table> {
+async fn commit_append(
+    catalog: &dyn Catalog,
+    table: &Table,
+    files: Vec<DataFile>,
+) -> Result<Table> {
     let tx = Transaction::new(table);
     let action = tx.fast_append().add_data_files(files);
     let tx = action.apply(tx).map_err(CubismIcebergError::Iceberg)?;
-    tx.commit(catalog).await.map_err(CubismIcebergError::Iceberg)
+    tx.commit(catalog)
+        .await
+        .map_err(CubismIcebergError::Iceberg)
 }
 
 /// Day-partition `bucket_start` and write via [`ClusteredWriter`] — sorted
@@ -150,14 +167,16 @@ async fn write_states_partitioned(
 ) -> Result<Vec<DataFile>> {
     let schema = table.metadata().current_schema().clone();
     let partition_spec = table.metadata().default_partition_spec().as_ref().clone();
-    let location_generator = DefaultLocationGenerator::new(table.metadata()).map_err(CubismIcebergError::Iceberg)?;
+    let location_generator =
+        DefaultLocationGenerator::new(table.metadata()).map_err(CubismIcebergError::Iceberg)?;
     let file_name_generator =
         DefaultFileNameGenerator::new(format!("states-{run_id}"), None, DataFileFormat::Parquet);
     // Callers build their Arrow batches by column name (see
     // `augment_states_batch`), not with Iceberg's `PARQUET:field_id` Arrow
     // metadata — match by name rather than the crate's default ID mode.
-    let parquet_writer_builder = ParquetWriterBuilder::new(WriterProperties::default(), schema.clone())
-        .with_match_mode(FieldMatchMode::Name);
+    let parquet_writer_builder =
+        ParquetWriterBuilder::new(WriterProperties::default(), schema.clone())
+            .with_match_mode(FieldMatchMode::Name);
     let rolling_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(
         parquet_writer_builder,
         table.file_io().clone(),
@@ -167,19 +186,22 @@ async fn write_states_partitioned(
     let data_file_writer_builder = DataFileWriterBuilder::new(rolling_writer_builder);
     let mut writer = ClusteredWriter::new(data_file_writer_builder);
 
-    let day_transform = create_transform_function(&Transform::Day).map_err(CubismIcebergError::Iceberg)?;
+    let day_transform =
+        create_transform_function(&Transform::Day).map_err(CubismIcebergError::Iceberg)?;
 
     for batch in batches {
         if batch.num_rows() == 0 {
             continue;
         }
-        let bucket_start = batch
-            .column_by_name("bucket_start")
-            .ok_or_else(|| CubismIcebergError::Iceberg(iceberg::Error::new(
+        let bucket_start = batch.column_by_name("bucket_start").ok_or_else(|| {
+            CubismIcebergError::Iceberg(iceberg::Error::new(
                 iceberg::ErrorKind::DataInvalid,
                 "states batch is missing its 'bucket_start' column",
-            )))?;
-        let days = day_transform.transform(bucket_start.clone()).map_err(CubismIcebergError::Iceberg)?;
+            ))
+        })?;
+        let days = day_transform
+            .transform(bucket_start.clone())
+            .map_err(CubismIcebergError::Iceberg)?;
         let days = days
             .as_any()
             .downcast_ref::<Date32Array>()
@@ -211,14 +233,16 @@ async fn write_unpartitioned(
     batches: &[RecordBatch],
 ) -> Result<Vec<DataFile>> {
     let schema = table.metadata().current_schema().clone();
-    let location_generator = DefaultLocationGenerator::new(table.metadata()).map_err(CubismIcebergError::Iceberg)?;
+    let location_generator =
+        DefaultLocationGenerator::new(table.metadata()).map_err(CubismIcebergError::Iceberg)?;
     let file_name_generator =
         DefaultFileNameGenerator::new(format!("{prefix}-{run_id}"), None, DataFileFormat::Parquet);
     // Callers build their Arrow batches by column name (see
     // `augment_states_batch`), not with Iceberg's `PARQUET:field_id` Arrow
     // metadata — match by name rather than the crate's default ID mode.
-    let parquet_writer_builder = ParquetWriterBuilder::new(WriterProperties::default(), schema.clone())
-        .with_match_mode(FieldMatchMode::Name);
+    let parquet_writer_builder =
+        ParquetWriterBuilder::new(WriterProperties::default(), schema.clone())
+            .with_match_mode(FieldMatchMode::Name);
     let rolling_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(
         parquet_writer_builder,
         table.file_io().clone(),
@@ -226,13 +250,19 @@ async fn write_unpartitioned(
         file_name_generator,
     );
     let data_file_writer_builder = DataFileWriterBuilder::new(rolling_writer_builder);
-    let mut writer = data_file_writer_builder.build(None).await.map_err(CubismIcebergError::Iceberg)?;
+    let mut writer = data_file_writer_builder
+        .build(None)
+        .await
+        .map_err(CubismIcebergError::Iceberg)?;
 
     for batch in batches {
         if batch.num_rows() == 0 {
             continue;
         }
-        writer.write(batch.clone()).await.map_err(CubismIcebergError::Iceberg)?;
+        writer
+            .write(batch.clone())
+            .await
+            .map_err(CubismIcebergError::Iceberg)?;
     }
 
     writer.close().await.map_err(CubismIcebergError::Iceberg)
@@ -241,11 +271,20 @@ async fn write_unpartitioned(
 /// Prepend `window_id`/`revision`/`run_id` constant columns to a Phase-2
 /// states batch, matching [`crate::schema::states_iceberg_schema`]'s field
 /// order and types exactly.
-fn augment_states_batch(batch: &RecordBatch, window_id: &str, revision: i64, run_id: &str) -> Result<RecordBatch> {
+fn augment_states_batch(
+    batch: &RecordBatch,
+    window_id: &str,
+    revision: i64,
+    run_id: &str,
+) -> Result<RecordBatch> {
     let n = batch.num_rows();
-    let window_col: Arc<dyn Array> = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(window_id, n)));
+    let window_col: Arc<dyn Array> = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+        window_id, n,
+    )));
     let revision_col: Arc<dyn Array> = Arc::new(Int64Array::from(vec![revision; n]));
-    let run_col: Arc<dyn Array> = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(run_id, n)));
+    let run_col: Arc<dyn Array> = Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+        run_id, n,
+    )));
 
     let mut fields = vec![
         Arc::new(Field::new(WINDOW_ID_COLUMN, DataType::Utf8, false)),
@@ -272,21 +311,31 @@ mod tests {
 
     #[test]
     fn a_duplicate_path_is_rejected_before_commit() {
-        let error = assert_unique_paths(["a.parquet", "b.parquet", "a.parquet"].into_iter()).unwrap_err();
-        assert!(matches!(error, CubismIcebergError::DuplicateDataFilePath(path) if path == "a.parquet"));
+        let error =
+            assert_unique_paths(["a.parquet", "b.parquet", "a.parquet"].into_iter()).unwrap_err();
+        assert!(
+            matches!(error, CubismIcebergError::DuplicateDataFilePath(path) if path == "a.parquet")
+        );
     }
 
     #[test]
     fn augmenting_a_batch_prepends_identity_columns_in_schema_order() {
         let inner = RecordBatch::try_new(
-            std::sync::Arc::new(ArrowSchema::new(vec![Field::new("x", DataType::Int64, false)])),
+            std::sync::Arc::new(ArrowSchema::new(vec![Field::new(
+                "x",
+                DataType::Int64,
+                false,
+            )])),
             vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
         )
         .unwrap();
         let augmented = augment_states_batch(&inner, "w-1", 7, "run-1").unwrap();
         let schema = augmented.schema();
         let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
-        assert_eq!(names, vec![WINDOW_ID_COLUMN, REVISION_COLUMN, RUN_ID_COLUMN, "x"]);
+        assert_eq!(
+            names,
+            vec![WINDOW_ID_COLUMN, REVISION_COLUMN, RUN_ID_COLUMN, "x"]
+        );
         assert_eq!(augmented.num_rows(), 3);
     }
 }

--- a/crates/cubism-iceberg/tests/concurrency.rs
+++ b/crates/cubism-iceberg/tests/concurrency.rs
@@ -83,14 +83,26 @@ async fn two_same_window_writers_produce_exactly_one_published_winner() {
     let store_b = Arc::new(PublicationStore::sqlite(&control_db).await.unwrap());
 
     let claim_a = store_a
-        .claim_run(CUBE_ID, &window_id, "run-a", WindowRevision::new(1).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-a",
+            WindowRevision::new(1).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     assert!(matches!(claim_a, ClaimResult::New(_)));
     store_a.record_append("run-a", 101).await.unwrap();
 
     let claim_b = store_b
-        .claim_run(CUBE_ID, &window_id, "run-b", WindowRevision::new(2).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-b",
+            WindowRevision::new(2).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     assert!(matches!(claim_b, ClaimResult::New(_)));
@@ -122,11 +134,25 @@ async fn two_same_window_writers_produce_exactly_one_published_winner() {
     let result_b = result_b.unwrap();
 
     let winner_revision = match (&result_a, &result_b) {
-        (Ok(publication), Err(CubismIcebergError::StaleRevision { expected: None, actual: Some(actual), .. })) => {
+        (
+            Ok(publication),
+            Err(CubismIcebergError::StaleRevision {
+                expected: None,
+                actual: Some(actual),
+                ..
+            }),
+        ) => {
             assert_eq!(*actual, publication.revision.get());
             publication.revision
         }
-        (Err(CubismIcebergError::StaleRevision { expected: None, actual: Some(actual), .. }), Ok(publication)) => {
+        (
+            Err(CubismIcebergError::StaleRevision {
+                expected: None,
+                actual: Some(actual),
+                ..
+            }),
+            Ok(publication),
+        ) => {
             assert_eq!(*actual, publication.revision.get());
             publication.revision
         }
@@ -148,7 +174,11 @@ async fn two_same_window_writers_produce_exactly_one_published_winner() {
     // The loser's own run must still be `Appended`, never silently marked
     // `Published` -- `publish` only flips that status on the branch that
     // actually wins the CAS.
-    let loser_run_id = if winner_revision.get() == 1 { "run-b" } else { "run-a" };
+    let loser_run_id = if winner_revision.get() == 1 {
+        "run-b"
+    } else {
+        "run-a"
+    };
     let loser_state = store_c.run_state(loser_run_id).await.unwrap().unwrap();
     assert!(
         matches!(loser_state, RunState::Appended { .. }),
@@ -171,10 +201,19 @@ async fn concurrent_publish_of_the_same_run_from_two_handles_is_idempotent() {
 
     for store in [&store_a, &store_b] {
         let claim = store
-            .claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-1",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
             .await
             .unwrap();
-        assert!(matches!(claim, ClaimResult::New(_) | ClaimResult::Existing(_)));
+        assert!(matches!(
+            claim,
+            ClaimResult::New(_) | ClaimResult::Existing(_)
+        ));
         store.record_append("run-1", 101).await.unwrap();
     }
 
@@ -199,7 +238,10 @@ async fn concurrent_publish_of_the_same_run_from_two_handles_is_idempotent() {
     let (result_a, result_b) = tokio::join!(task_a, task_b);
     let publication_a = result_a.unwrap().unwrap();
     let publication_b = result_b.unwrap().unwrap();
-    assert_eq!(publication_a, publication_b, "both handles must observe the same published revision, not a race");
+    assert_eq!(
+        publication_a, publication_b,
+        "both handles must observe the same published revision, not a race"
+    );
 }
 
 /// Phase 4's "disjoint windows can commit concurrently"
@@ -249,14 +291,26 @@ async fn disjoint_windows_can_commit_concurrently_without_conflicting() {
     let store_b = Arc::new(PublicationStore::sqlite(&control_db).await.unwrap());
 
     let claim_a = store_a
-        .claim_run(CUBE_ID, &window_a, "run-a", WindowRevision::new(1).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_a,
+            "run-a",
+            WindowRevision::new(1).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     assert!(matches!(claim_a, ClaimResult::New(_)));
     store_a.record_append("run-a", 201).await.unwrap();
 
     let claim_b = store_b
-        .claim_run(CUBE_ID, &window_b, "run-b", WindowRevision::new(1).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_b,
+            "run-b",
+            WindowRevision::new(1).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     assert!(matches!(claim_b, ClaimResult::New(_)));
@@ -281,8 +335,12 @@ async fn disjoint_windows_can_commit_concurrently_without_conflicting() {
     };
 
     let (result_a, result_b) = tokio::join!(task_a, task_b);
-    let publication_a = result_a.unwrap().expect("window A's own publish must not be rejected by window B's activity");
-    let publication_b = result_b.unwrap().expect("window B's own publish must not be rejected by window A's activity");
+    let publication_a = result_a
+        .unwrap()
+        .expect("window A's own publish must not be rejected by window B's activity");
+    let publication_b = result_b
+        .unwrap()
+        .expect("window B's own publish must not be rejected by window A's activity");
     assert_eq!(publication_a.run_id, "run-a");
     assert_eq!(publication_b.run_id, "run-b");
 
@@ -316,21 +374,35 @@ async fn publish_waits_for_a_concurrently_held_write_lock_then_succeeds() {
 
     let store = Arc::new(PublicationStore::sqlite(&control_db).await.unwrap());
     store
-        .claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-1",
+            WindowRevision::new(1).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     store.record_append("run-1", 101).await.unwrap();
 
     let mut holder = SqliteConnection::connect_with(
-        &SqliteConnectOptions::new().filename(&control_db).busy_timeout(std::time::Duration::from_secs(5)),
+        &SqliteConnectOptions::new()
+            .filename(&control_db)
+            .busy_timeout(std::time::Duration::from_secs(5)),
     )
     .await
     .unwrap();
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut holder).await.unwrap();
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut holder)
+        .await
+        .unwrap();
     // Any write against the shared database file is enough to hold the
     // RESERVED lock -- this table has nothing to do with the control store's
     // own schema.
-    sqlx::query("CREATE TABLE lock_probe (id INTEGER)").execute(&mut holder).await.unwrap();
+    sqlx::query("CREATE TABLE lock_probe (id INTEGER)")
+        .execute(&mut holder)
+        .await
+        .unwrap();
 
     let publish_task = {
         let store = Arc::clone(&store);
@@ -344,7 +416,10 @@ async fn publish_waits_for_a_concurrently_held_write_lock_then_succeeds() {
     sqlx::query("COMMIT").execute(&mut holder).await.unwrap();
 
     let result = publish_task.await.unwrap();
-    assert!(result.is_ok(), "publish must succeed once the concurrent holder releases the lock: {result:?}");
+    assert!(
+        result.is_ok(),
+        "publish must succeed once the concurrent holder releases the lock: {result:?}"
+    );
 }
 
 /// Forces `with_immediate_tx`'s Rust-level retry loop
@@ -444,21 +519,35 @@ async fn retry_loop_resolves_a_write_lock_held_past_busy_timeout() {
 
     let store = Arc::new(PublicationStore::sqlite(&control_db).await.unwrap());
     store
-        .claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-1",
+            WindowRevision::new(1).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     store.record_append("run-1", 101).await.unwrap();
 
     let mut holder = SqliteConnection::connect_with(
-        &SqliteConnectOptions::new().filename(&control_db).busy_timeout(std::time::Duration::from_secs(5)),
+        &SqliteConnectOptions::new()
+            .filename(&control_db)
+            .busy_timeout(std::time::Duration::from_secs(5)),
     )
     .await
     .unwrap();
-    sqlx::query("BEGIN IMMEDIATE").execute(&mut holder).await.unwrap();
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut holder)
+        .await
+        .unwrap();
     // Any write against the shared database file is enough to hold the
     // RESERVED lock -- this table has nothing to do with the control store's
     // own schema.
-    sqlx::query("CREATE TABLE lock_probe (id INTEGER)").execute(&mut holder).await.unwrap();
+    sqlx::query("CREATE TABLE lock_probe (id INTEGER)")
+        .execute(&mut holder)
+        .await
+        .unwrap();
 
     let publish_task = {
         let store = Arc::clone(&store);
@@ -483,7 +572,10 @@ async fn retry_loop_resolves_a_write_lock_held_past_busy_timeout() {
 
     let (result, publish_elapsed) = publish_task.await.unwrap();
 
-    assert!(result.is_ok(), "publish must succeed once the concurrent holder releases the lock: {result:?}");
+    assert!(
+        result.is_ok(),
+        "publish must succeed once the concurrent holder releases the lock: {result:?}"
+    );
     assert!(
         publish_elapsed > std::time::Duration::from_secs(6),
         "publish itself took only {publish_elapsed:?} -- at or before busy_timeout's 5s give-up point -- \

--- a/crates/cubism-iceberg/tests/coordinator.rs
+++ b/crates/cubism-iceberg/tests/coordinator.rs
@@ -35,8 +35,8 @@ use chrono::DateTime;
 use cubism_core::AggKind;
 use cubism_core::temporal::{WindowId, WindowRevision};
 use cubism_iceberg::{
-    AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, ClaimResult, CorrectionCoordinator,
-    CorrectionRequest, CubismIcebergError, PublicationStore, TemporalTable,
+    AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, ClaimResult,
+    CorrectionCoordinator, CorrectionRequest, CubismIcebergError, PublicationStore, TemporalTable,
 };
 use iceberg::Catalog;
 use tempfile::TempDir;
@@ -44,7 +44,9 @@ use tempfile::TempDir;
 const CUBE_ID: &str = "web_analytics";
 
 fn micros(timestamp: &str) -> i64 {
-    DateTime::parse_from_rfc3339(timestamp).unwrap().timestamp_micros()
+    DateTime::parse_from_rfc3339(timestamp)
+        .unwrap()
+        .timestamp_micros()
 }
 
 fn xunit_id(tag: u8) -> [u8; 32] {
@@ -70,14 +72,20 @@ fn sample_states_schema() -> ArrowSchema {
 }
 
 fn states_batch(rows: &[(&str, [u8; 32], i64, f64)]) -> RecordBatch {
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _, _)| *x)).unwrap();
     let count = Int64Array::from_iter_values(rows.iter().map(|(_, _, c, _)| *c));
     let sum = Float64Array::from_iter_values(rows.iter().map(|(_, _, _, s)| *s));
     RecordBatch::try_new(
         Arc::new(sample_states_schema()),
-        vec![Arc::new(bucket_start), Arc::new(xunit_id), Arc::new(count), Arc::new(sum)],
+        vec![
+            Arc::new(bucket_start),
+            Arc::new(xunit_id),
+            Arc::new(count),
+            Arc::new(sum),
+        ],
     )
     .unwrap()
 }
@@ -149,12 +157,20 @@ struct Fixture {
 impl Fixture {
     async fn new() -> Self {
         let warehouse = TempDir::new().unwrap();
-        let config = CatalogConfig::Memory { warehouse: warehouse.path().to_path_buf() };
+        let config = CatalogConfig::Memory {
+            warehouse: warehouse.path().to_path_buf(),
+        };
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
-            .await
-            .unwrap();
-        Self { _warehouse: warehouse, catalog, temporal_table, publications: PublicationStore::in_memory() }
+        let temporal_table =
+            TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+                .await
+                .unwrap();
+        Self {
+            _warehouse: warehouse,
+            catalog,
+            temporal_table,
+            publications: PublicationStore::in_memory(),
+        }
     }
 
     /// Publish `states`/`registry` as a from-scratch first revision — the
@@ -162,7 +178,12 @@ impl Fixture {
     /// window's initial build goes through this path, never
     /// `CorrectionCoordinator` (see that module's doc comment on why
     /// `observed_current` is a required `WindowRevision`, not `Option`).
-    async fn publish_initial(&self, window_id: &WindowId, states: &[RecordBatch], registry: &[RecordBatch]) {
+    async fn publish_initial(
+        &self,
+        window_id: &WindowId,
+        states: &[RecordBatch],
+        registry: &[RecordBatch],
+    ) {
         let expected_rows: u64 = states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
         let revision = WindowRevision::new(1).unwrap();
         let claim = self
@@ -174,16 +195,34 @@ impl Fixture {
         let result = AggregateWriter::append_window(
             self.catalog.as_ref(),
             &self.temporal_table,
-            AppendWindow { window_id, revision, run_id: "run-initial", states, registry },
+            AppendWindow {
+                window_id,
+                revision,
+                run_id: "run-initial",
+                states,
+                registry,
+            },
         )
         .await
         .unwrap();
-        self.publications.record_append("run-initial", result.snapshot_id).await.unwrap();
-        self.publications.publish("run-initial", None).await.unwrap();
+        self.publications
+            .record_append("run-initial", result.snapshot_id)
+            .await
+            .unwrap();
+        self.publications
+            .publish("run-initial", None)
+            .await
+            .unwrap();
     }
 
     async fn read(&self, window_id: &WindowId) -> cubism_iceberg::error::Result<Vec<RecordBatch>> {
-        AggregateReader::read_window(self.catalog.as_ref(), &self.temporal_table, &self.publications, window_id).await
+        AggregateReader::read_window(
+            self.catalog.as_ref(),
+            &self.temporal_table,
+            &self.publications,
+            window_id,
+        )
+        .await
     }
 }
 
@@ -195,14 +234,24 @@ async fn coordinator_correction_is_revision_isolated_from_a_from_scratch_publish
         ("2026-08-12T00:10:00Z", xunit_id(1), 3, 9.0),
         ("2026-08-12T00:20:00Z", xunit_id(2), 5, 11.0),
     ])];
-    let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile"), (xunit_id(2), b"EU/desktop")])];
+    let corrected_registry = vec![registry_batch(&[
+        (xunit_id(1), b"US/mobile"),
+        (xunit_id(2), b"EU/desktop"),
+    ])];
 
     // Path A: publish a partial (pre-correction) revision, then run
     // `CorrectionCoordinator` to replace it with the full corrected data.
     let fixture_a = Fixture::new().await;
-    let partial_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 3, 9.0)])];
+    let partial_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        3,
+        9.0,
+    )])];
     let partial_registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile")])];
-    fixture_a.publish_initial(&window_id, &partial_states, &partial_registry).await;
+    fixture_a
+        .publish_initial(&window_id, &partial_states, &partial_registry)
+        .await;
 
     let request = CorrectionRequest {
         window_id: &window_id,
@@ -233,7 +282,9 @@ async fn coordinator_correction_is_revision_isolated_from_a_from_scratch_publish
     // Path B: a fresh fixture publishes the exact same corrected content
     // once, from scratch, as revision 1 — no correction involved.
     let fixture_b = Fixture::new().await;
-    fixture_b.publish_initial(&window_id, &corrected_states, &corrected_registry).await;
+    fixture_b
+        .publish_initial(&window_id, &corrected_states, &corrected_registry)
+        .await;
     let clean_read = fixture_b.read(&window_id).await.unwrap();
 
     assert_eq!(
@@ -244,23 +295,42 @@ async fn coordinator_correction_is_revision_isolated_from_a_from_scratch_publish
 }
 
 #[tokio::test]
-async fn coordinator_rejects_a_correction_planned_against_a_superseded_revision_and_does_not_move_current() {
+async fn coordinator_rejects_a_correction_planned_against_a_superseded_revision_and_does_not_move_current()
+ {
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
 
     // A second writer publishes revision 2 directly (not via the
     // coordinator) before the correction below gets a chance to run —
     // simulating a concurrent build that moved `current` out from under a
     // correction that was planned against revision 1.
-    let states_v2 = vec![states_batch(&[("2026-08-12T00:15:00Z", xunit_id(2), 2, 2.0)])];
+    let states_v2 = vec![states_batch(&[(
+        "2026-08-12T00:15:00Z",
+        xunit_id(2),
+        2,
+        2.0,
+    )])];
     let registry_v2 = vec![registry_batch(&[(xunit_id(2), b"b")])];
     let claim = fixture
         .publications
-        .claim_run(CUBE_ID, &window_id, "run-concurrent", WindowRevision::new(2).unwrap(), 1)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-concurrent",
+            WindowRevision::new(2).unwrap(),
+            1,
+        )
         .await
         .unwrap();
     assert!(matches!(claim, ClaimResult::New(_)));
@@ -277,14 +347,27 @@ async fn coordinator_rejects_a_correction_planned_against_a_superseded_revision_
     )
     .await
     .unwrap();
-    fixture.publications.record_append("run-concurrent", result.snapshot_id).await.unwrap();
-    fixture.publications.publish("run-concurrent", Some(WindowRevision::new(1).unwrap())).await.unwrap();
+    fixture
+        .publications
+        .record_append("run-concurrent", result.snapshot_id)
+        .await
+        .unwrap();
+    fixture
+        .publications
+        .publish("run-concurrent", Some(WindowRevision::new(1).unwrap()))
+        .await
+        .unwrap();
 
     // The correction below still observed revision 1 as current (planned
     // before the concurrent write above landed) — the coordinator must
     // surface the CAS rejection as-is and must not retry it internally
     // (see `coordinator.rs`'s module doc comment).
-    let corrected_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 9, 9.0)])];
+    let corrected_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        9,
+        9.0,
+    )])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let request = CorrectionRequest {
         window_id: &window_id,
@@ -305,11 +388,19 @@ async fn coordinator_rejects_a_correction_planned_against_a_superseded_revision_
     .unwrap_err();
     assert!(matches!(
         error,
-        CubismIcebergError::StaleRevision { expected: Some(1), actual: Some(2), .. }
+        CubismIcebergError::StaleRevision {
+            expected: Some(1),
+            actual: Some(2),
+            ..
+        }
     ));
 
     assert_eq!(
-        fixture.publications.current(CUBE_ID, &window_id).await.unwrap(),
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
         Some(WindowRevision::new(2).unwrap()),
         "a rejected correction must not move `current`"
     );
@@ -332,21 +423,37 @@ async fn coordinator_skips_a_redundant_append_when_the_run_was_already_appended(
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
 
     let corrected_states = vec![states_batch(&[
         ("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0),
         ("2026-08-12T00:20:00Z", xunit_id(2), 2, 2.0),
     ])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a"), (xunit_id(2), b"b")])];
-    let expected_rows: u64 = corrected_states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
+    let expected_rows: u64 = corrected_states
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum::<usize>() as u64;
     let revision = WindowRevision::new(2).unwrap();
 
     let claim = fixture
         .publications
-        .claim_run(CUBE_ID, &window_id, "run-correction", revision, expected_rows)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-correction",
+            revision,
+            expected_rows,
+        )
         .await
         .unwrap();
     assert!(matches!(claim, ClaimResult::New(_)));
@@ -363,7 +470,11 @@ async fn coordinator_skips_a_redundant_append_when_the_run_was_already_appended(
     )
     .await
     .unwrap();
-    fixture.publications.record_append("run-correction", first_append.snapshot_id).await.unwrap();
+    fixture
+        .publications
+        .record_append("run-correction", first_append.snapshot_id)
+        .await
+        .unwrap();
 
     let request = CorrectionRequest {
         window_id: &window_id,
@@ -389,7 +500,11 @@ async fn coordinator_skips_a_redundant_append_when_the_run_was_already_appended(
     );
 
     let read = fixture.read(&window_id).await.unwrap();
-    assert_eq!(total_rows(&read), 2, "a retried append-skip path must not duplicate rows");
+    assert_eq!(
+        total_rows(&read),
+        2,
+        "a retried append-skip path must not duplicate rows"
+    );
 }
 
 /// Proves the benign side of `coordinator.rs`'s #20 fix: replaying
@@ -407,15 +522,28 @@ async fn coordinator_skips_a_redundant_append_when_the_run_was_already_appended(
 /// involved (isolating the #20 guard's own logic from durability/restart
 /// concerns, which is that other test's job).
 #[tokio::test]
-async fn coordinator_replaying_a_published_correction_with_nothing_changed_returns_the_same_publication() {
+async fn coordinator_replaying_a_published_correction_with_nothing_changed_returns_the_same_publication()
+ {
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
 
-    let corrected_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 9, 9.0)])];
+    let corrected_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        9,
+        9.0,
+    )])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let build_request = || CorrectionRequest {
         window_id: &window_id,
@@ -476,17 +604,37 @@ async fn coordinator_replaying_a_published_correction_with_nothing_changed_retur
 /// shape (a run that crashed before its own publish) — that gap is
 /// deliberately out of scope for this fix, tracked as #21.
 #[tokio::test]
-async fn coordinator_rejects_a_replayed_correction_after_a_rollback_restored_its_observed_current() {
+async fn coordinator_rejects_a_replayed_correction_after_a_rollback_restored_its_observed_current()
+{
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
-    assert_eq!(fixture.publications.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(1).unwrap()));
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
+    assert_eq!(
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
+        Some(WindowRevision::new(1).unwrap())
+    );
 
     // The correction: revision B, moving `current` from A (1) to B (2).
-    let corrected_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 9, 9.0)])];
+    let corrected_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        9,
+        9.0,
+    )])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let original_request = || CorrectionRequest {
         window_id: &window_id,
@@ -506,15 +654,30 @@ async fn coordinator_rejects_a_replayed_correction_after_a_rollback_restored_its
     .await
     .unwrap();
     assert_eq!(published.revision, WindowRevision::new(2).unwrap());
-    assert_eq!(fixture.publications.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
 
     // The rollback: republish `run-initial` (revision A) via the same CAS
     // `publish` call, expecting the current B — the existing, already-
     // shipped rollback mechanism (`docs/TIMESERIES_PHASE_13_HANDOFF.md`),
     // not new code under test here.
-    fixture.publications.publish("run-initial", Some(WindowRevision::new(2).unwrap())).await.unwrap();
+    fixture
+        .publications
+        .publish("run-initial", Some(WindowRevision::new(2).unwrap()))
+        .await
+        .unwrap();
     assert_eq!(
-        fixture.publications.current(CUBE_ID, &window_id).await.unwrap(),
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
         Some(WindowRevision::new(1).unwrap()),
         "rollback should have restored current to revision A"
     );
@@ -534,11 +697,19 @@ async fn coordinator_rejects_a_replayed_correction_after_a_rollback_restored_its
     .unwrap_err();
     assert!(matches!(
         error,
-        CubismIcebergError::RunNoLongerCurrent { revision: 2, current: Some(1), .. }
+        CubismIcebergError::RunNoLongerCurrent {
+            revision: 2,
+            current: Some(1),
+            ..
+        }
     ));
 
     assert_eq!(
-        fixture.publications.current(CUBE_ID, &window_id).await.unwrap(),
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
         Some(WindowRevision::new(1).unwrap()),
         "a rejected replay must not undo the rollback — current must stay at revision A"
     );
@@ -572,20 +743,43 @@ async fn coordinator_rejects_a_replayed_correction_after_a_rollback_restored_its
 /// implementation comment (pre-claim staleness; the concurrent
 /// check-vs-publish race).
 #[tokio::test]
-async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_rollback_restored_its_observed_current() {
+async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_rollback_restored_its_observed_current()
+ {
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
-    assert_eq!(fixture.publications.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(1).unwrap()));
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
+    assert_eq!(
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
+        Some(WindowRevision::new(1).unwrap())
+    );
 
     // The crashed correction: claimed + appended + recorded, never
     // published. Its request still carries `observed_current: A`.
-    let corrected_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 9, 9.0)])];
+    let corrected_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        9,
+        9.0,
+    )])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    let expected_rows: u64 = corrected_states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
+    let expected_rows: u64 = corrected_states
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum::<usize>() as u64;
     let crashed_request = || CorrectionRequest {
         window_id: &window_id,
         revision: WindowRevision::new(2).unwrap(),
@@ -597,7 +791,13 @@ async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_roll
     };
     let claim = fixture
         .publications
-        .claim_run(CUBE_ID, &window_id, "run-correction", WindowRevision::new(2).unwrap(), expected_rows)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-correction",
+            WindowRevision::new(2).unwrap(),
+            expected_rows,
+        )
         .await
         .unwrap();
     assert!(matches!(claim, ClaimResult::New(_)));
@@ -614,10 +814,19 @@ async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_roll
     )
     .await
     .unwrap();
-    fixture.publications.record_append("run-correction", crashed_append.snapshot_id).await.unwrap();
+    fixture
+        .publications
+        .record_append("run-correction", crashed_append.snapshot_id)
+        .await
+        .unwrap();
 
     // A different, real correction completes normally: revision C (3).
-    let later_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 5, 5.0)])];
+    let later_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        5,
+        5.0,
+    )])];
     let later_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let published = CorrectionCoordinator::execute(
         fixture.catalog.as_ref(),
@@ -639,9 +848,17 @@ async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_roll
 
     // The operator's deliberate rollback to A — undoing run-second-
     // correction, with no knowledge of the crashed run.
-    fixture.publications.publish("run-initial", Some(WindowRevision::new(3).unwrap())).await.unwrap();
+    fixture
+        .publications
+        .publish("run-initial", Some(WindowRevision::new(3).unwrap()))
+        .await
+        .unwrap();
     assert_eq!(
-        fixture.publications.current(CUBE_ID, &window_id).await.unwrap(),
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
         Some(WindowRevision::new(1).unwrap()),
         "rollback should have restored current to revision A"
     );
@@ -661,14 +878,23 @@ async fn coordinator_rejects_a_replayed_awaiting_publish_correction_after_a_roll
     assert!(
         matches!(
             error,
-            CubismIcebergError::WindowChangedSinceClaim { observed_generation: 1, current_generation: 3, current: Some(1), .. }
+            CubismIcebergError::WindowChangedSinceClaim {
+                observed_generation: 1,
+                current_generation: 3,
+                current: Some(1),
+                ..
+            }
         ),
         "expected WindowChangedSinceClaim with the claim-time generation (1) vs the live one after \
          correction-plus-rollback (3) and the rolled-back current revision"
     );
 
     assert_eq!(
-        fixture.publications.current(CUBE_ID, &window_id).await.unwrap(),
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
         Some(WindowRevision::new(1).unwrap()),
         "a rejected replay must not undo the rollback — current must stay at revision A"
     );
@@ -692,9 +918,16 @@ async fn coordinator_completes_an_interrupted_correction_when_nothing_changed_si
     let window_id = WindowId::new("2026-08-12").unwrap();
     let fixture = Fixture::new().await;
 
-    let states_v1 = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states_v1 = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a")])];
-    fixture.publish_initial(&window_id, &states_v1, &registry_v1).await;
+    fixture
+        .publish_initial(&window_id, &states_v1, &registry_v1)
+        .await;
 
     // Stage the interrupted run: claimed + appended + recorded, never
     // published, nothing else touching the window afterward.
@@ -703,10 +936,19 @@ async fn coordinator_completes_an_interrupted_correction_when_nothing_changed_si
         ("2026-08-12T00:20:00Z", xunit_id(2), 2, 2.0),
     ])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a"), (xunit_id(2), b"b")])];
-    let expected_rows: u64 = corrected_states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
+    let expected_rows: u64 = corrected_states
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum::<usize>() as u64;
     let claim = fixture
         .publications
-        .claim_run(CUBE_ID, &window_id, "run-correction", WindowRevision::new(2).unwrap(), expected_rows)
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-correction",
+            WindowRevision::new(2).unwrap(),
+            expected_rows,
+        )
         .await
         .unwrap();
     assert!(matches!(claim, ClaimResult::New(_)));
@@ -723,7 +965,11 @@ async fn coordinator_completes_an_interrupted_correction_when_nothing_changed_si
     )
     .await
     .unwrap();
-    fixture.publications.record_append("run-correction", staged_append.snapshot_id).await.unwrap();
+    fixture
+        .publications
+        .record_append("run-correction", staged_append.snapshot_id)
+        .await
+        .unwrap();
 
     let request = CorrectionRequest {
         window_id: &window_id,
@@ -747,5 +993,12 @@ async fn coordinator_completes_an_interrupted_correction_when_nothing_changed_si
         publication.aggregate_snapshot_id, staged_append.snapshot_id,
         "recovery must complete the interrupted run's own publish, not perform a second append"
     );
-    assert_eq!(fixture.publications.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        fixture
+            .publications
+            .current(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
 }

--- a/crates/cubism-iceberg/tests/durability.rs
+++ b/crates/cubism-iceberg/tests/durability.rs
@@ -15,16 +15,18 @@
 
 use std::sync::Arc;
 
-use arrow_array::{FixedSizeBinaryArray, Float64Array, Int64Array, RecordBatch, TimestampMicrosecondArray};
+use arrow_array::{
+    FixedSizeBinaryArray, Float64Array, Int64Array, RecordBatch, TimestampMicrosecondArray,
+};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
 use chrono::DateTime;
 use cubism_core::AggKind;
 use cubism_core::temporal::{WindowId, WindowRevision};
 use cubism_iceberg::table::current_snapshot_id;
 use cubism_iceberg::{
-    AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, ClaimResult, CorrectionCoordinator,
-    CorrectionRequest, CubismIcebergError, PublicationStore, ReconciliationRecord, RevisionStatus, RunInspection,
-    RunState, TemporalTable,
+    AggregateReader, AggregateWriter, AppendWindow, CatalogConfig, ClaimResult,
+    CorrectionCoordinator, CorrectionRequest, CubismIcebergError, PublicationStore,
+    ReconciliationRecord, RevisionStatus, RunInspection, RunState, TemporalTable,
 };
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
@@ -32,7 +34,9 @@ use tempfile::TempDir;
 const CUBE_ID: &str = "web_analytics";
 
 fn micros(timestamp: &str) -> i64 {
-    DateTime::parse_from_rfc3339(timestamp).unwrap().timestamp_micros()
+    DateTime::parse_from_rfc3339(timestamp)
+        .unwrap()
+        .timestamp_micros()
 }
 
 fn xunit_id(tag: u8) -> [u8; 32] {
@@ -55,14 +59,20 @@ fn sample_states_schema() -> ArrowSchema {
 }
 
 fn states_batch(rows: &[(&str, [u8; 32], i64, f64)]) -> RecordBatch {
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _, _)| *x)).unwrap();
     let count = Int64Array::from_iter_values(rows.iter().map(|(_, _, c, _)| *c));
     let sum = Float64Array::from_iter_values(rows.iter().map(|(_, _, _, s)| *s));
     RecordBatch::try_new(
         Arc::new(sample_states_schema()),
-        vec![Arc::new(bucket_start), Arc::new(xunit_id), Arc::new(count), Arc::new(sum)],
+        vec![
+            Arc::new(bucket_start),
+            Arc::new(xunit_id),
+            Arc::new(count),
+            Arc::new(sum),
+        ],
     )
     .unwrap()
 }
@@ -96,7 +106,9 @@ async fn sqlite_catalog_tables_are_visible_from_a_freshly_opened_handle() {
     // so this really does release the only reference).
     {
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+        TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+            .await
+            .unwrap();
     }
 
     // Second handle, same paths, no shared state with the first: this is
@@ -115,7 +127,9 @@ async fn sqlite_catalog_tables_are_visible_from_a_freshly_opened_handle() {
     // TemporalTable::create must also be idempotent from the fresh handle
     // (its own `table_exists` checks must see the first handle's tables,
     // not attempt — and fail — to recreate them).
-    TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -132,7 +146,12 @@ async fn an_append_committed_by_one_handle_is_readable_after_publishing_from_a_s
 
     let window_id = WindowId::new("2026-08-12").unwrap();
     let revision = WindowRevision::new(1).unwrap();
-    let states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 3, 9.0)])];
+    let states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        3,
+        9.0,
+    )])];
     let registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile")])];
 
     // First handle: create tables, claim, append. Deliberately does NOT
@@ -140,7 +159,9 @@ async fn an_append_committed_by_one_handle_is_readable_after_publishing_from_a_s
     // up the claim/append state and finishes the job.
     let snapshot_id = {
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
         let claim = publications
             .claim_run(CUBE_ID, &window_id, "run-1", revision, 3)
@@ -150,11 +171,20 @@ async fn an_append_committed_by_one_handle_is_readable_after_publishing_from_a_s
         let result = AggregateWriter::append_window(
             catalog.as_ref(),
             &table,
-            AppendWindow { window_id: &window_id, revision, run_id: "run-1", states: &states, registry: &registry },
+            AppendWindow {
+                window_id: &window_id,
+                revision,
+                run_id: "run-1",
+                states: &states,
+                registry: &registry,
+            },
         )
         .await
         .unwrap();
-        publications.record_append("run-1", result.snapshot_id).await.unwrap();
+        publications
+            .record_append("run-1", result.snapshot_id)
+            .await
+            .unwrap();
         result.snapshot_id
     };
 
@@ -162,24 +192,43 @@ async fn an_append_committed_by_one_handle_is_readable_after_publishing_from_a_s
     // sharing anything with the first. It reconciles the existing claim
     // (Existing(Appended)) instead of re-appending, then publishes.
     let catalog_b = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
     let publications_b = PublicationStore::sqlite(&control_db).await.unwrap();
 
-    let reclaim = publications_b.claim_run(CUBE_ID, &window_id, "run-1", revision, 3).await.unwrap();
+    let reclaim = publications_b
+        .claim_run(CUBE_ID, &window_id, "run-1", revision, 3)
+        .await
+        .unwrap();
     let recovered_snapshot = match &reclaim {
-        ClaimResult::Existing(cubism_iceberg::RunState::Appended { aggregate_snapshot_id, .. }) => *aggregate_snapshot_id,
+        ClaimResult::Existing(cubism_iceberg::RunState::Appended {
+            aggregate_snapshot_id,
+            ..
+        }) => *aggregate_snapshot_id,
         other => panic!("expected Existing(Appended {{ .. }}) from a fresh handle, got {other:?}"),
     };
-    assert_eq!(recovered_snapshot, snapshot_id, "the recovered snapshot id must match what the first handle committed");
+    assert_eq!(
+        recovered_snapshot, snapshot_id,
+        "the recovered snapshot id must match what the first handle committed"
+    );
 
     let expected_current = publications_b.current(CUBE_ID, &window_id).await.unwrap();
     assert_eq!(expected_current, None, "not published yet");
-    publications_b.publish("run-1", expected_current).await.unwrap();
-
-    let visible = AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id)
+    publications_b
+        .publish("run-1", expected_current)
         .await
         .unwrap();
-    assert_eq!(total_rows(&visible), 1, "the first handle's append must be visible after the second handle publishes");
+
+    let visible =
+        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id)
+            .await
+            .unwrap();
+    assert_eq!(
+        total_rows(&visible),
+        1,
+        "the first handle's append must be visible after the second handle publishes"
+    );
 }
 
 #[tokio::test]
@@ -190,7 +239,16 @@ async fn sqlite_publication_store_cas_survives_reopen_from_a_fresh_handle() {
 
     {
         let store = PublicationStore::sqlite(&control_db).await.unwrap();
-        store.claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1).await.unwrap();
+        store
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-1",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
+            .await
+            .unwrap();
         store.record_append("run-1", 101).await.unwrap();
         store.publish("run-1", None).await.unwrap();
     }
@@ -200,24 +258,52 @@ async fn sqlite_publication_store_cas_survives_reopen_from_a_fresh_handle() {
     // through SQLite, not through anything held in this process's memory.
     let store_b = PublicationStore::sqlite(&control_db).await.unwrap();
     let current = store_b.current(CUBE_ID, &window_id).await.unwrap();
-    assert_eq!(current, Some(WindowRevision::new(1).unwrap()), "publication from the dropped handle must be visible");
+    assert_eq!(
+        current,
+        Some(WindowRevision::new(1).unwrap()),
+        "publication from the dropped handle must be visible"
+    );
 
-    store_b.claim_run(CUBE_ID, &window_id, "run-2", WindowRevision::new(2).unwrap(), 1).await.unwrap();
+    store_b
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-2",
+            WindowRevision::new(2).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
     store_b.record_append("run-2", 102).await.unwrap();
 
     // A real CAS: this must be rejected because the caller's belief about
     // the current revision (99) does not match what the fresh handle can
     // see (1) — not a hardcoded `None` that any first publish would accept.
-    let stale = store_b.publish("run-2", Some(WindowRevision::new(99).unwrap())).await;
-    assert!(matches!(stale, Err(CubismIcebergError::StaleRevision { expected: Some(99), actual: Some(1), .. })));
+    let stale = store_b
+        .publish("run-2", Some(WindowRevision::new(99).unwrap()))
+        .await;
+    assert!(matches!(
+        stale,
+        Err(CubismIcebergError::StaleRevision {
+            expected: Some(99),
+            actual: Some(1),
+            ..
+        })
+    ));
 
     store_b.publish("run-2", current).await.unwrap();
-    assert_eq!(store_b.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        store_b.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
 
     // A third handle sees run-2's publication too, not just what handle B
     // did in its own memory.
     let store_c = PublicationStore::sqlite(&control_db).await.unwrap();
-    assert_eq!(store_c.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        store_c.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
 }
 
 /// Roadmap Milestone 2 (`docs/TIMESERIES_ROADMAP.md`): a correction computed
@@ -252,13 +338,34 @@ async fn sqlite_correction_against_a_superseded_revision_is_rejected_then_succee
         // again. Both happen on a handle that is then dropped, so run-3
         // below cannot see either through anything but the database.
         let store = PublicationStore::sqlite(&control_db).await.unwrap();
-        store.claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1).await.unwrap();
+        store
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-1",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
+            .await
+            .unwrap();
         store.record_append("run-1", 101).await.unwrap();
         store.publish("run-1", None).await.unwrap();
 
-        store.claim_run(CUBE_ID, &window_id, "run-2", WindowRevision::new(2).unwrap(), 1).await.unwrap();
+        store
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-2",
+                WindowRevision::new(2).unwrap(),
+                1,
+            )
+            .await
+            .unwrap();
         store.record_append("run-2", 102).await.unwrap();
-        store.publish("run-2", Some(WindowRevision::new(1).unwrap())).await.unwrap();
+        store
+            .publish("run-2", Some(WindowRevision::new(1).unwrap()))
+            .await
+            .unwrap();
     }
 
     // run-3 is the correction, on a freshly-opened handle: it was computed
@@ -266,24 +373,51 @@ async fn sqlite_correction_against_a_superseded_revision_is_rejected_then_succee
     // a guessed-wrong value like the reopen test above uses, and not a
     // belief carried over in this process's memory from the block above.
     let store_b = PublicationStore::sqlite(&control_db).await.unwrap();
-    store_b.claim_run(CUBE_ID, &window_id, "run-3", WindowRevision::new(3).unwrap(), 1).await.unwrap();
+    store_b
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-3",
+            WindowRevision::new(3).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
     store_b.record_append("run-3", 103).await.unwrap();
-    let stale = store_b.publish("run-3", Some(WindowRevision::new(1).unwrap())).await;
-    assert!(matches!(stale, Err(CubismIcebergError::StaleRevision { expected: Some(1), actual: Some(2), .. })));
+    let stale = store_b
+        .publish("run-3", Some(WindowRevision::new(1).unwrap()))
+        .await;
+    assert!(matches!(
+        stale,
+        Err(CubismIcebergError::StaleRevision {
+            expected: Some(1),
+            actual: Some(2),
+            ..
+        })
+    ));
     // The rejected correction must not have moved `current`.
-    assert_eq!(store_b.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        store_b.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
 
     // Refresh-and-retry: the correction re-reads `current`, retries with the
     // refreshed expected revision, and succeeds — the protocol Milestone 4's
     // coordinator will need for a real correction run.
     let refreshed = store_b.current(CUBE_ID, &window_id).await.unwrap();
     store_b.publish("run-3", refreshed).await.unwrap();
-    assert_eq!(store_b.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(3).unwrap()));
+    assert_eq!(
+        store_b.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(3).unwrap())
+    );
 
     // A third, freshly-opened handle sees the corrected revision too, not
     // just handle B's in-memory belief about its own retry.
     let store_c = PublicationStore::sqlite(&control_db).await.unwrap();
-    assert_eq!(store_c.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(3).unwrap()));
+    assert_eq!(
+        store_c.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(3).unwrap())
+    );
 }
 
 /// Roadmap Milestone 5 (`docs/TIMESERIES_ROADMAP.md`): `ReconciliationRecord`
@@ -323,25 +457,42 @@ async fn sqlite_correction_against_a_superseded_revision_is_rejected_then_succee
 /// already proves it, against the in-memory backend; this test does not
 /// duplicate that coverage.
 #[tokio::test]
-async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a_published_run_after_reopen() {
+async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a_published_run_after_reopen()
+ {
     let warehouse = TempDir::new().unwrap();
     let catalog_dir = TempDir::new().unwrap();
     let catalog_db = catalog_dir.path().join("catalog.sqlite");
     let control_dir = TempDir::new().unwrap();
     let control_db = control_dir.path().join("control.sqlite");
-    let config = CatalogConfig::Sqlite { warehouse: warehouse.path().to_path_buf(), catalog_db: catalog_db.clone() };
+    let config = CatalogConfig::Sqlite {
+        warehouse: warehouse.path().to_path_buf(),
+        catalog_db: catalog_db.clone(),
+    };
     let window_id = WindowId::new("2026-08-12").unwrap();
 
     // An initial revision 1 is published directly (raw protocol) so the
     // correction below has something to replace.
-    let initial_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let initial_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let initial_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     {
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
         let claim = publications
-            .claim_run(CUBE_ID, &window_id, "run-initial", WindowRevision::new(1).unwrap(), 1)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-initial",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
             .await
             .unwrap();
         assert!(matches!(claim, ClaimResult::New(_)));
@@ -358,7 +509,10 @@ async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a
         )
         .await
         .unwrap();
-        publications.record_append("run-initial", result.snapshot_id).await.unwrap();
+        publications
+            .record_append("run-initial", result.snapshot_id)
+            .await
+            .unwrap();
         publications.publish("run-initial", None).await.unwrap();
     }
 
@@ -370,17 +524,28 @@ async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a
         ("2026-08-12T00:20:00Z", xunit_id(2), 2, 2.0),
     ])];
     let corrected_registry = vec![registry_batch(&[(xunit_id(1), b"a"), (xunit_id(2), b"b")])];
-    let expected_rows: u64 = corrected_states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
+    let expected_rows: u64 = corrected_states
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum::<usize>() as u64;
     {
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
         let claim = publications
-            .claim_run(CUBE_ID, &window_id, "run-correction", WindowRevision::new(2).unwrap(), expected_rows)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-correction",
+                WindowRevision::new(2).unwrap(),
+                expected_rows,
+            )
             .await
             .unwrap();
         assert!(matches!(claim, ClaimResult::New(_)));
         assert_eq!(
             ReconciliationRecord::classify(Some(claim.state())),
-            ReconciliationRecord::AwaitingAppend { revision: WindowRevision::new(2).unwrap() }
+            ReconciliationRecord::AwaitingAppend {
+                revision: WindowRevision::new(2).unwrap()
+            }
         );
     }
 
@@ -397,7 +562,9 @@ async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a
         registry: &corrected_registry,
     };
     let catalog_b = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
     let publications_b = PublicationStore::sqlite(&control_db).await.unwrap();
 
     // Confirm the claim actually survived the restart, observed through
@@ -407,23 +574,33 @@ async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a
     let recovered = publications_b.run_state("run-correction").await.unwrap();
     assert_eq!(
         ReconciliationRecord::classify(recovered.as_ref()),
-        ReconciliationRecord::AwaitingAppend { revision: WindowRevision::new(2).unwrap() },
+        ReconciliationRecord::AwaitingAppend {
+            revision: WindowRevision::new(2).unwrap()
+        },
         "the claim must survive the restart as AwaitingAppend, observed through a fresh handle"
     );
 
     let first_publication =
-        CorrectionCoordinator::execute(catalog_b.as_ref(), &table_b, &publications_b, request).await.unwrap();
+        CorrectionCoordinator::execute(catalog_b.as_ref(), &table_b, &publications_b, request)
+            .await
+            .unwrap();
     assert_eq!(first_publication.revision, WindowRevision::new(2).unwrap());
 
     let read_after_recovery =
-        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id).await.unwrap();
+        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id)
+            .await
+            .unwrap();
     assert_eq!(
         total_rows(&read_after_recovery),
         2,
         "recovering a claimed-but-unattempted run must append exactly once"
     );
 
-    let run_state_after = publications_b.run_state("run-correction").await.unwrap().unwrap();
+    let run_state_after = publications_b
+        .run_state("run-correction")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         ReconciliationRecord::classify(Some(&run_state_after)),
         ReconciliationRecord::Published {
@@ -446,18 +623,32 @@ async fn sqlite_coordinator_execute_recovers_an_unattempted_claim_then_replays_a
         registry: &corrected_registry,
     };
     let catalog_c = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-    let table_c = TemporalTable::create(catalog_c.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    let table_c = TemporalTable::create(catalog_c.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
     let publications_c = PublicationStore::sqlite(&control_db).await.unwrap();
-    let replayed_publication =
-        CorrectionCoordinator::execute(catalog_c.as_ref(), &table_c, &publications_c, request_retry).await.unwrap();
+    let replayed_publication = CorrectionCoordinator::execute(
+        catalog_c.as_ref(),
+        &table_c,
+        &publications_c,
+        request_retry,
+    )
+    .await
+    .unwrap();
     assert_eq!(
         replayed_publication, first_publication,
         "replaying a completed correction after a restart must return the identical publication, not a new one"
     );
 
     let read_after_replay =
-        AggregateReader::read_window(catalog_c.as_ref(), &table_c, &publications_c, &window_id).await.unwrap();
-    assert_eq!(total_rows(&read_after_replay), 2, "replaying a completed correction must not duplicate rows");
+        AggregateReader::read_window(catalog_c.as_ref(), &table_c, &publications_c, &window_id)
+            .await
+            .unwrap();
+    assert_eq!(
+        total_rows(&read_after_replay),
+        2,
+        "replaying a completed correction must not duplicate rows"
+    );
 }
 
 /// [Issue #17](https://github.com/jeromebanks/cubism-rs/issues/17)'s fix:
@@ -765,10 +956,18 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
     let catalog_db = catalog_dir.path().join("catalog.sqlite");
     let control_dir = TempDir::new().unwrap();
     let control_db = control_dir.path().join("control.sqlite");
-    let config = CatalogConfig::Sqlite { warehouse: warehouse.path().to_path_buf(), catalog_db: catalog_db.clone() };
+    let config = CatalogConfig::Sqlite {
+        warehouse: warehouse.path().to_path_buf(),
+        catalog_db: catalog_db.clone(),
+    };
     let window_id = WindowId::new("2026-08-12").unwrap();
 
-    let original_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let original_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let original_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let corrected_states = vec![states_batch(&[
         ("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0),
@@ -782,11 +981,19 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
     // anything but the database.
     let (original_snapshot_id, corrected_snapshot_id) = {
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
 
         publications
-            .claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-1",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
             .await
             .unwrap();
         let result = AggregateWriter::append_window(
@@ -802,11 +1009,20 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
         )
         .await
         .unwrap();
-        publications.record_append("run-1", result.snapshot_id).await.unwrap();
+        publications
+            .record_append("run-1", result.snapshot_id)
+            .await
+            .unwrap();
         publications.publish("run-1", None).await.unwrap();
 
         publications
-            .claim_run(CUBE_ID, &window_id, "run-2", WindowRevision::new(2).unwrap(), 2)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-2",
+                WindowRevision::new(2).unwrap(),
+                2,
+            )
             .await
             .unwrap();
         let result2 = AggregateWriter::append_window(
@@ -822,8 +1038,14 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
         )
         .await
         .unwrap();
-        publications.record_append("run-2", result2.snapshot_id).await.unwrap();
-        publications.publish("run-2", Some(WindowRevision::new(1).unwrap())).await.unwrap();
+        publications
+            .record_append("run-2", result2.snapshot_id)
+            .await
+            .unwrap();
+        publications
+            .publish("run-2", Some(WindowRevision::new(1).unwrap()))
+            .await
+            .unwrap();
 
         (result.snapshot_id, result2.snapshot_id)
     };
@@ -832,25 +1054,44 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
     // revision 2 is current and its 2 rows are visible before rolling
     // back — the baseline the rollback below must actually change.
     let catalog_b = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    let table_b = TemporalTable::create(catalog_b.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
     let publications_b = PublicationStore::sqlite(&control_db).await.unwrap();
-    assert_eq!(publications_b.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
+    assert_eq!(
+        publications_b.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
     let before_rollback =
-        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id).await.unwrap();
-    assert_eq!(total_rows(&before_rollback), 2, "revision 2's 2 rows must be visible before rollback");
+        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id)
+            .await
+            .unwrap();
+    assert_eq!(
+        total_rows(&before_rollback),
+        2,
+        "revision 2's 2 rows must be visible before rollback"
+    );
 
     // The rollback: re-publish run-1's own already-claimed, fixed revision
     // against the window's actual current revision (2) as the CAS anchor.
     // No new claim, no new append, no new run_id — the existing mechanism,
     // called a second time.
-    let rolled_back = publications_b.publish("run-1", Some(WindowRevision::new(2).unwrap())).await.unwrap();
+    let rolled_back = publications_b
+        .publish("run-1", Some(WindowRevision::new(2).unwrap()))
+        .await
+        .unwrap();
     assert_eq!(rolled_back.revision, WindowRevision::new(1).unwrap());
     assert_eq!(rolled_back.run_id, "run-1");
     assert_eq!(rolled_back.aggregate_snapshot_id, original_snapshot_id);
 
-    assert_eq!(publications_b.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(1).unwrap()));
+    assert_eq!(
+        publications_b.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(1).unwrap())
+    );
     let after_rollback =
-        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id).await.unwrap();
+        AggregateReader::read_window(catalog_b.as_ref(), &table_b, &publications_b, &window_id)
+            .await
+            .unwrap();
     assert_eq!(
         total_rows(&after_rollback),
         1,
@@ -860,12 +1101,23 @@ async fn publish_repoints_a_window_to_a_prior_published_revision_via_the_existin
     // A third, freshly-opened handle pair sees the rollback too, not just
     // handle B's in-memory belief about its own write.
     let catalog_c = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-    let table_c = TemporalTable::create(catalog_c.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+    let table_c = TemporalTable::create(catalog_c.as_ref(), CUBE_ID, &sample_states_schema())
+        .await
+        .unwrap();
     let publications_c = PublicationStore::sqlite(&control_db).await.unwrap();
-    assert_eq!(publications_c.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(1).unwrap()));
+    assert_eq!(
+        publications_c.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(1).unwrap())
+    );
     let read_c =
-        AggregateReader::read_window(catalog_c.as_ref(), &table_c, &publications_c, &window_id).await.unwrap();
-    assert_eq!(total_rows(&read_c), 1, "a third fresh handle must see the rollback too");
+        AggregateReader::read_window(catalog_c.as_ref(), &table_c, &publications_c, &window_id)
+            .await
+            .unwrap();
+    assert_eq!(
+        total_rows(&read_c),
+        1,
+        "a third fresh handle must see the rollback too"
+    );
 
     // The consequence #18 tracks, proven directly rather than inferred: the
     // rollback above touched only `control_publications` and run-1's own
@@ -899,10 +1151,18 @@ async fn run_inspection_distinguishes_the_rolled_back_to_run_from_the_rolled_bac
     let catalog_db = catalog_dir.path().join("catalog.sqlite");
     let control_dir = TempDir::new().unwrap();
     let control_db = control_dir.path().join("control.sqlite");
-    let config = CatalogConfig::Sqlite { warehouse: warehouse.path().to_path_buf(), catalog_db: catalog_db.clone() };
+    let config = CatalogConfig::Sqlite {
+        warehouse: warehouse.path().to_path_buf(),
+        catalog_db: catalog_db.clone(),
+    };
     let window_id = WindowId::new("2026-08-12").unwrap();
 
-    let original_states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let original_states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let original_registry = vec![registry_batch(&[(xunit_id(1), b"a")])];
     let corrected_states = vec![states_batch(&[
         ("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0),
@@ -916,11 +1176,19 @@ async fn run_inspection_distinguishes_the_rolled_back_to_run_from_the_rolled_bac
     // holds.
     {
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
 
         publications
-            .claim_run(CUBE_ID, &window_id, "run-1", WindowRevision::new(1).unwrap(), 1)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-1",
+                WindowRevision::new(1).unwrap(),
+                1,
+            )
             .await
             .unwrap();
         let result = AggregateWriter::append_window(
@@ -936,11 +1204,20 @@ async fn run_inspection_distinguishes_the_rolled_back_to_run_from_the_rolled_bac
         )
         .await
         .unwrap();
-        publications.record_append("run-1", result.snapshot_id).await.unwrap();
+        publications
+            .record_append("run-1", result.snapshot_id)
+            .await
+            .unwrap();
         publications.publish("run-1", None).await.unwrap();
 
         publications
-            .claim_run(CUBE_ID, &window_id, "run-2", WindowRevision::new(2).unwrap(), 2)
+            .claim_run(
+                CUBE_ID,
+                &window_id,
+                "run-2",
+                WindowRevision::new(2).unwrap(),
+                2,
+            )
             .await
             .unwrap();
         let result2 = AggregateWriter::append_window(
@@ -956,23 +1233,40 @@ async fn run_inspection_distinguishes_the_rolled_back_to_run_from_the_rolled_bac
         )
         .await
         .unwrap();
-        publications.record_append("run-2", result2.snapshot_id).await.unwrap();
-        publications.publish("run-2", Some(WindowRevision::new(1).unwrap())).await.unwrap();
+        publications
+            .record_append("run-2", result2.snapshot_id)
+            .await
+            .unwrap();
+        publications
+            .publish("run-2", Some(WindowRevision::new(1).unwrap()))
+            .await
+            .unwrap();
 
-        publications.publish("run-1", Some(WindowRevision::new(2).unwrap())).await.unwrap();
+        publications
+            .publish("run-1", Some(WindowRevision::new(2).unwrap()))
+            .await
+            .unwrap();
     }
 
     // A fresh handle inspects both runs.
     let publications_b = PublicationStore::sqlite(&control_db).await.unwrap();
 
-    let run1 = RunInspection::inspect(&publications_b, CUBE_ID, &window_id, "run-1").await.unwrap();
+    let run1 = RunInspection::inspect(&publications_b, CUBE_ID, &window_id, "run-1")
+        .await
+        .unwrap();
     assert!(matches!(
         run1.record,
         ReconciliationRecord::Published { revision, .. } if revision == WindowRevision::new(1).unwrap()
     ));
-    assert_eq!(run1.revision_status, Some(RevisionStatus::Current), "run-1 was rolled back to; it is current");
+    assert_eq!(
+        run1.revision_status,
+        Some(RevisionStatus::Current),
+        "run-1 was rolled back to; it is current"
+    );
 
-    let run2 = RunInspection::inspect(&publications_b, CUBE_ID, &window_id, "run-2").await.unwrap();
+    let run2 = RunInspection::inspect(&publications_b, CUBE_ID, &window_id, "run-2")
+        .await
+        .unwrap();
     assert!(matches!(
         run2.record,
         ReconciliationRecord::Published { revision, .. } if revision == WindowRevision::new(2).unwrap()
@@ -1021,9 +1315,14 @@ async fn sqlite_control_store_migration_adds_generation_columns_and_preserves_re
         // content shaped like an upgrade-time snapshot: revision 1 live
         // ("run-old"), and one correction parked at AwaitingPublish
         // ("run-legacy", revision 2).
-        let options =
-            SqliteConnectOptions::new().filename(&control_db).create_if_missing(true);
-        let pool = SqlitePoolOptions::new().max_connections(1).connect_with(options).await.unwrap();
+        let options = SqliteConnectOptions::new()
+            .filename(&control_db)
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
         sqlx::query(
             "CREATE TABLE control_runs (
                 run_id TEXT PRIMARY KEY,
@@ -1077,7 +1376,13 @@ async fn sqlite_control_store_migration_adds_generation_columns_and_preserves_re
 
     let state = store.run_state("run-legacy").await.unwrap();
     assert!(
-        matches!(&state, Some(RunState::Appended { aggregate_snapshot_id: 101, .. })),
+        matches!(
+            &state,
+            Some(RunState::Appended {
+                aggregate_snapshot_id: 101,
+                ..
+            })
+        ),
         "the pre-migration mid-recovery row must read back unchanged through the migrated schema"
     );
     assert_eq!(
@@ -1088,12 +1393,36 @@ async fn sqlite_control_store_migration_adds_generation_columns_and_preserves_re
     );
 
     // The interrupted run is still recoverable across the upgrade.
-    store.publish("run-legacy", Some(WindowRevision::new(1).unwrap())).await.unwrap();
-    assert_eq!(store.current(CUBE_ID, &window_id).await.unwrap(), Some(WindowRevision::new(2).unwrap()));
-    assert_eq!(store.publication_generation(CUBE_ID, &window_id).await.unwrap(), 1);
+    store
+        .publish("run-legacy", Some(WindowRevision::new(1).unwrap()))
+        .await
+        .unwrap();
+    assert_eq!(
+        store.current(CUBE_ID, &window_id).await.unwrap(),
+        Some(WindowRevision::new(2).unwrap())
+    );
+    assert_eq!(
+        store
+            .publication_generation(CUBE_ID, &window_id)
+            .await
+            .unwrap(),
+        1
+    );
 
     // Claims taken after migration record a real anchor: the generation as
     // of this claim (1, after run-legacy's changing publish above).
-    store.claim_run(CUBE_ID, &window_id, "run-post", WindowRevision::new(3).unwrap(), 1).await.unwrap();
-    assert_eq!(store.run_observed_generation("run-post").await.unwrap(), Some(1));
+    store
+        .claim_run(
+            CUBE_ID,
+            &window_id,
+            "run-post",
+            WindowRevision::new(3).unwrap(),
+            1,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store.run_observed_generation("run-post").await.unwrap(),
+        Some(1)
+    );
 }

--- a/crates/cubism-iceberg/tests/phase3.rs
+++ b/crates/cubism-iceberg/tests/phase3.rs
@@ -7,8 +7,8 @@
 
 use std::sync::Arc;
 
-use arrow_array::{Float64Array, Int64Array, RecordBatch, TimestampMicrosecondArray};
 use arrow_array::FixedSizeBinaryArray;
+use arrow_array::{Float64Array, Int64Array, RecordBatch, TimestampMicrosecondArray};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema, TimeUnit};
 use chrono::DateTime;
 use cubism_core::temporal::{WindowId, WindowRevision};
@@ -17,15 +17,17 @@ use cubism_iceberg::{
     PublicationStore, RunState, TemporalTable,
 };
 use futures::TryStreamExt;
+use iceberg::Catalog;
 use iceberg::expr::Reference;
 use iceberg::spec::{Datum, Transform};
-use iceberg::Catalog;
 use tempfile::TempDir;
 
 const CUBE_ID: &str = "web_analytics";
 
 fn micros(timestamp: &str) -> i64 {
-    DateTime::parse_from_rfc3339(timestamp).unwrap().timestamp_micros()
+    DateTime::parse_from_rfc3339(timestamp)
+        .unwrap()
+        .timestamp_micros()
 }
 
 fn xunit_id(tag: u8) -> [u8; 32] {
@@ -51,14 +53,20 @@ fn sample_states_schema() -> ArrowSchema {
 }
 
 fn states_batch(rows: &[(&str, [u8; 32], i64, f64)]) -> RecordBatch {
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _, _)| *x)).unwrap();
     let count = Int64Array::from_iter_values(rows.iter().map(|(_, _, c, _)| *c));
     let sum = Float64Array::from_iter_values(rows.iter().map(|(_, _, _, s)| *s));
     RecordBatch::try_new(
         Arc::new(sample_states_schema()),
-        vec![Arc::new(bucket_start), Arc::new(xunit_id), Arc::new(count), Arc::new(sum)],
+        vec![
+            Arc::new(bucket_start),
+            Arc::new(xunit_id),
+            Arc::new(count),
+            Arc::new(sum),
+        ],
     )
     .unwrap()
 }
@@ -87,12 +95,20 @@ struct Fixture {
 impl Fixture {
     async fn new() -> Self {
         let warehouse = TempDir::new().unwrap();
-        let config = CatalogConfig::Memory { warehouse: warehouse.path().to_path_buf() };
+        let config = CatalogConfig::Memory {
+            warehouse: warehouse.path().to_path_buf(),
+        };
         let catalog = cubism_iceberg::config::open_catalog(&config).await.unwrap();
-        let temporal_table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
-            .await
-            .unwrap();
-        Self { _warehouse: warehouse, catalog, temporal_table, publications: PublicationStore::in_memory() }
+        let temporal_table =
+            TemporalTable::create(catalog.as_ref(), CUBE_ID, &sample_states_schema())
+                .await
+                .unwrap();
+        Self {
+            _warehouse: warehouse,
+            catalog,
+            temporal_table,
+            publications: PublicationStore::in_memory(),
+        }
     }
 
     async fn append(
@@ -109,21 +125,39 @@ impl Fixture {
             .claim_run(CUBE_ID, window_id, run_id, revision, expected_rows)
             .await
             .unwrap();
-        assert!(matches!(claim, ClaimResult::New(_)), "expected a fresh claim for {run_id}");
+        assert!(
+            matches!(claim, ClaimResult::New(_)),
+            "expected a fresh claim for {run_id}"
+        );
 
         let result = AggregateWriter::append_window(
             self.catalog.as_ref(),
             &self.temporal_table,
-            AppendWindow { window_id, revision, run_id, states, registry },
+            AppendWindow {
+                window_id,
+                revision,
+                run_id,
+                states,
+                registry,
+            },
         )
         .await
         .unwrap();
-        self.publications.record_append(run_id, result.snapshot_id).await.unwrap();
+        self.publications
+            .record_append(run_id, result.snapshot_id)
+            .await
+            .unwrap();
         result
     }
 
     async fn read(&self, window_id: &WindowId) -> cubism_iceberg::error::Result<Vec<RecordBatch>> {
-        AggregateReader::read_window(self.catalog.as_ref(), &self.temporal_table, &self.publications, window_id).await
+        AggregateReader::read_window(
+            self.catalog.as_ref(),
+            &self.temporal_table,
+            &self.publications,
+            window_id,
+        )
+        .await
     }
 }
 
@@ -131,7 +165,11 @@ impl Fixture {
 async fn states_and_registry_tables_have_the_expected_iceberg_schema_partition_and_sort() {
     let fixture = Fixture::new().await;
 
-    let states_table = fixture.temporal_table.states_table(fixture.catalog.as_ref()).await.unwrap();
+    let states_table = fixture
+        .temporal_table
+        .states_table(fixture.catalog.as_ref())
+        .await
+        .unwrap();
     let metadata = states_table.metadata();
     let schema = metadata.current_schema();
     assert_eq!(schema.field_by_id(1).unwrap().name, "window_id");
@@ -144,7 +182,10 @@ async fn states_and_registry_tables_have_the_expected_iceberg_schema_partition_a
 
     let partition_fields = metadata.default_partition_spec().fields();
     assert_eq!(partition_fields.len(), 1);
-    assert_eq!(partition_fields[0].source_id, 4, "partitions on bucket_start's field id");
+    assert_eq!(
+        partition_fields[0].source_id, 4,
+        "partitions on bucket_start's field id"
+    );
     assert_eq!(partition_fields[0].transform, Transform::Day);
 
     let sort_fields = &metadata.default_sort_order().fields;
@@ -152,11 +193,34 @@ async fn states_and_registry_tables_have_the_expected_iceberg_schema_partition_a
     assert_eq!(sort_fields[0].source_id, 4);
     assert_eq!(sort_fields[1].source_id, 5);
 
-    let registry_table = fixture.temporal_table.registry_table(fixture.catalog.as_ref()).await.unwrap();
+    let registry_table = fixture
+        .temporal_table
+        .registry_table(fixture.catalog.as_ref())
+        .await
+        .unwrap();
     let registry_metadata = registry_table.metadata();
-    assert_eq!(registry_metadata.current_schema().field_by_id(1).unwrap().name, "xunit_id");
-    assert_eq!(registry_metadata.current_schema().field_by_id(2).unwrap().name, "xunit_canonical");
-    assert!(registry_metadata.default_partition_spec().fields().is_empty());
+    assert_eq!(
+        registry_metadata
+            .current_schema()
+            .field_by_id(1)
+            .unwrap()
+            .name,
+        "xunit_id"
+    );
+    assert_eq!(
+        registry_metadata
+            .current_schema()
+            .field_by_id(2)
+            .unwrap()
+            .name,
+        "xunit_canonical"
+    );
+    assert!(
+        registry_metadata
+            .default_partition_spec()
+            .fields()
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -167,14 +231,36 @@ async fn append_window_returns_the_exact_committed_snapshot_id_and_row_count() {
         ("2026-08-12T00:10:00Z", xunit_id(1), 3, 9.0),
         ("2026-08-12T00:20:00Z", xunit_id(2), 5, 11.0),
     ])];
-    let registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile"), (xunit_id(2), b"EU/desktop")])];
+    let registry = vec![registry_batch(&[
+        (xunit_id(1), b"US/mobile"),
+        (xunit_id(2), b"EU/desktop"),
+    ])];
 
-    let result = fixture.append(&window_id, WindowRevision::new(1).unwrap(), "run-1", &states, &registry).await;
+    let result = fixture
+        .append(
+            &window_id,
+            WindowRevision::new(1).unwrap(),
+            "run-1",
+            &states,
+            &registry,
+        )
+        .await;
     assert_eq!(result.row_count, 2);
 
-    let states_table = fixture.temporal_table.states_table(fixture.catalog.as_ref()).await.unwrap();
-    let actual_snapshot = states_table.metadata().current_snapshot().unwrap().snapshot_id();
-    assert_eq!(result.snapshot_id, actual_snapshot, "CommitResult must report the exact committed snapshot, not a row count");
+    let states_table = fixture
+        .temporal_table
+        .states_table(fixture.catalog.as_ref())
+        .await
+        .unwrap();
+    let actual_snapshot = states_table
+        .metadata()
+        .current_snapshot()
+        .unwrap()
+        .snapshot_id();
+    assert_eq!(
+        result.snapshot_id, actual_snapshot,
+        "CommitResult must report the exact committed snapshot, not a row count"
+    );
 }
 
 #[tokio::test]
@@ -182,40 +268,82 @@ async fn retrying_the_same_run_id_after_a_simulated_crash_does_not_double_append
     let fixture = Fixture::new().await;
     let window_id = WindowId::new("2026-08-12").unwrap();
     let revision = WindowRevision::new(1).unwrap();
-    let states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 3, 9.0)])];
+    let states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        3,
+        9.0,
+    )])];
     let registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile")])];
 
-    let first = fixture.append(&window_id, revision, "run-1", &states, &registry).await;
+    let first = fixture
+        .append(&window_id, revision, "run-1", &states, &registry)
+        .await;
 
     // Simulate a process restart: the caller re-claims the same run_id
     // before it ever gets to `publish`.
-    let retry_claim = fixture.publications.claim_run(CUBE_ID, &window_id, "run-1", revision, 1).await.unwrap();
+    let retry_claim = fixture
+        .publications
+        .claim_run(CUBE_ID, &window_id, "run-1", revision, 1)
+        .await
+        .unwrap();
     let recovered_snapshot = match retry_claim {
         ClaimResult::Existing(RunState::Appended { .. }) => {
             fixture.publications.run_state("run-1").await.unwrap()
         }
         other => panic!("expected Existing(Appended {{ .. }}), got {other:?}"),
     };
-    assert!(recovered_snapshot.is_some(), "recovered run state must be observable without a second append");
+    assert!(
+        recovered_snapshot.is_some(),
+        "recovered run state must be observable without a second append"
+    );
 
     // The caller sees the run is already appended and skips straight to
     // publish — no second `AggregateWriter::append_window` call.
     fixture.publications.publish("run-1", None).await.unwrap();
 
     let batches = fixture.read(&window_id).await.unwrap();
-    assert_eq!(total_rows(&batches), 1, "a recovered retry must not have doubled the physical row count");
+    assert_eq!(
+        total_rows(&batches),
+        1,
+        "a recovered retry must not have doubled the physical row count"
+    );
 
-    let states_table = fixture.temporal_table.states_table(fixture.catalog.as_ref()).await.unwrap();
-    assert_eq!(states_table.metadata().current_snapshot().unwrap().snapshot_id(), first.snapshot_id);
+    let states_table = fixture
+        .temporal_table
+        .states_table(fixture.catalog.as_ref())
+        .await
+        .unwrap();
+    assert_eq!(
+        states_table
+            .metadata()
+            .current_snapshot()
+            .unwrap()
+            .snapshot_id(),
+        first.snapshot_id
+    );
 }
 
 #[tokio::test]
 async fn an_unpublished_revision_is_invisible_to_the_reader() {
     let fixture = Fixture::new().await;
     let window_id = WindowId::new("2026-08-12").unwrap();
-    let states = vec![states_batch(&[("2026-08-12T00:10:00Z", xunit_id(1), 1, 1.0)])];
+    let states = vec![states_batch(&[(
+        "2026-08-12T00:10:00Z",
+        xunit_id(1),
+        1,
+        1.0,
+    )])];
     let registry = vec![registry_batch(&[(xunit_id(1), b"US/mobile")])];
-    fixture.append(&window_id, WindowRevision::new(1).unwrap(), "run-1", &states, &registry).await;
+    fixture
+        .append(
+            &window_id,
+            WindowRevision::new(1).unwrap(),
+            "run-1",
+            &states,
+            &registry,
+        )
+        .await;
 
     let error = fixture.read(&window_id).await.unwrap_err();
     assert!(matches!(error, CubismIcebergError::UnpublishedWindow(_)));
@@ -231,21 +359,56 @@ async fn publishing_a_new_revision_replaces_visibility_of_the_prior_one() {
         ("2026-08-12T00:20:00Z", xunit_id(2), 2, 2.0),
     ])];
     let registry_v1 = vec![registry_batch(&[(xunit_id(1), b"a"), (xunit_id(2), b"b")])];
-    fixture.append(&window_id, WindowRevision::new(1).unwrap(), "run-1", &states_v1, &registry_v1).await;
+    fixture
+        .append(
+            &window_id,
+            WindowRevision::new(1).unwrap(),
+            "run-1",
+            &states_v1,
+            &registry_v1,
+        )
+        .await;
     fixture.publications.publish("run-1", None).await.unwrap();
 
     let visible_v1 = fixture.read(&window_id).await.unwrap();
     assert_eq!(total_rows(&visible_v1), 2);
 
-    let states_v2 = vec![states_batch(&[("2026-08-12T00:15:00Z", xunit_id(3), 9, 9.0)])];
+    let states_v2 = vec![states_batch(&[(
+        "2026-08-12T00:15:00Z",
+        xunit_id(3),
+        9,
+        9.0,
+    )])];
     let registry_v2 = vec![registry_batch(&[(xunit_id(3), b"c")])];
-    fixture.append(&window_id, WindowRevision::new(2).unwrap(), "run-2", &states_v2, &registry_v2).await;
-    let stale = fixture.publications.publish("run-2", Some(WindowRevision::new(99).unwrap())).await;
-    assert!(stale.is_err(), "publish must reject a caller that observed the wrong current revision");
-    fixture.publications.publish("run-2", Some(WindowRevision::new(1).unwrap())).await.unwrap();
+    fixture
+        .append(
+            &window_id,
+            WindowRevision::new(2).unwrap(),
+            "run-2",
+            &states_v2,
+            &registry_v2,
+        )
+        .await;
+    let stale = fixture
+        .publications
+        .publish("run-2", Some(WindowRevision::new(99).unwrap()))
+        .await;
+    assert!(
+        stale.is_err(),
+        "publish must reject a caller that observed the wrong current revision"
+    );
+    fixture
+        .publications
+        .publish("run-2", Some(WindowRevision::new(1).unwrap()))
+        .await
+        .unwrap();
 
     let visible_v2 = fixture.read(&window_id).await.unwrap();
-    assert_eq!(total_rows(&visible_v2), 1, "only revision 2's row should be visible, not both revisions summed");
+    assert_eq!(
+        total_rows(&visible_v2),
+        1,
+        "only revision 2's row should be visible, not both revisions summed"
+    );
 }
 
 #[tokio::test]
@@ -257,11 +420,36 @@ async fn day_partition_pruning_plans_one_file_for_a_bounded_scan() {
         ("2026-08-13T11:00:00Z", xunit_id(2), 2, 2.0),
     ])];
     let registry = vec![registry_batch(&[(xunit_id(1), b"a"), (xunit_id(2), b"b")])];
-    fixture.append(&window_id, WindowRevision::new(1).unwrap(), "run-1", &states, &registry).await;
+    fixture
+        .append(
+            &window_id,
+            WindowRevision::new(1).unwrap(),
+            "run-1",
+            &states,
+            &registry,
+        )
+        .await;
 
-    let states_table = fixture.temporal_table.states_table(fixture.catalog.as_ref()).await.unwrap();
-    let all_tasks = states_table.scan().build().unwrap().plan_files().await.unwrap().try_collect::<Vec<_>>().await.unwrap();
-    assert_eq!(all_tasks.len(), 2, "one append spanning two days should produce two day-partitioned files");
+    let states_table = fixture
+        .temporal_table
+        .states_table(fixture.catalog.as_ref())
+        .await
+        .unwrap();
+    let all_tasks = states_table
+        .scan()
+        .build()
+        .unwrap()
+        .plan_files()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        all_tasks.len(),
+        2,
+        "one append spanning two days should produce two day-partitioned files"
+    );
 
     let start = micros("2026-08-12T00:00:00Z");
     let end = micros("2026-08-13T00:00:00Z");
@@ -279,6 +467,10 @@ async fn day_partition_pruning_plans_one_file_for_a_bounded_scan() {
         .try_collect::<Vec<_>>()
         .await
         .unwrap();
-    assert_eq!(selected.len(), 1, "a one-day predicate should prune the other day's file");
+    assert_eq!(
+        selected.len(),
+        1,
+        "a one-day predicate should prune the other day's file"
+    );
     assert_eq!(selected[0].record_count, Some(1));
 }

--- a/crates/cubism-serve/src/api.rs
+++ b/crates/cubism-serve/src/api.rs
@@ -6,13 +6,13 @@
 //! aggregated together.
 
 use crate::store::{CubeStore, SketchKind};
+use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use cubism_core::sketch::KmvSketch;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub struct ApiError {
@@ -22,13 +22,19 @@ pub struct ApiError {
 
 impl ApiError {
     fn not_found(message: impl Into<String>) -> Self {
-        ApiError { status: StatusCode::NOT_FOUND, message: message.into() }
+        ApiError {
+            status: StatusCode::NOT_FOUND,
+            message: message.into(),
+        }
     }
     // `pub(crate)`: reused by `crate::series`'s handler so `/api/series`
     // reports errors in the same `{"error": "..."}` envelope as the
     // static-cube endpoints above, rather than inventing a second shape.
     pub(crate) fn bad_request(message: impl Into<String>) -> Self {
-        ApiError { status: StatusCode::BAD_REQUEST, message: message.into() }
+        ApiError {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
     }
 }
 
@@ -81,9 +87,13 @@ pub async fn cells(
             store.dimensions.join(", ")
         )));
     }
-    let sort = p.sort.unwrap_or_else(|| store.measures.first().cloned().unwrap_or_default());
+    let sort = p
+        .sort
+        .unwrap_or_else(|| store.measures.first().cloned().unwrap_or_default());
     if !store.measures.contains(&sort) {
-        return Err(ApiError::bad_request(format!("unknown sort measure '{sort}'")));
+        return Err(ApiError::bad_request(format!(
+            "unknown sort measure '{sort}'"
+        )));
     }
 
     let mut rows = store.slice(&p.dim, p.depth);
@@ -104,7 +114,9 @@ pub async fn cells(
             })
         })
         .collect();
-    Ok(Json(json!({"dim": p.dim, "depth": p.depth, "sort": sort, "cells": cells})))
+    Ok(Json(
+        json!({"dim": p.dim, "depth": p.depth, "sort": sort, "cells": cells}),
+    ))
 }
 
 #[derive(Deserialize)]
@@ -164,9 +176,9 @@ pub async fn setops(
         let row = store
             .row(xunit)
             .ok_or_else(|| ApiError::not_found(format!("no cell '{xunit}' in this cube")))?;
-        let blob = store
-            .blob(&measure, row)
-            .ok_or_else(|| ApiError::not_found(format!("cell '{xunit}' has no '{measure}' sketch")))?;
+        let blob = store.blob(&measure, row).ok_or_else(|| {
+            ApiError::not_found(format!("cell '{xunit}' has no '{measure}' sketch"))
+        })?;
         KmvSketch::from_bytes(blob)
             .map_err(|e| ApiError::bad_request(format!("cannot decode sketch: {e}")))
     };
@@ -179,7 +191,11 @@ pub async fn setops(
         .and_then(|blob| KmvSketch::from_bytes(blob).ok())
         .map(|g| {
             let inter = a.intersection_estimate(&b);
-            if inter == 0.0 { 0.0 } else { inter * g.estimate() / (a.estimate() * b.estimate()) }
+            if inter == 0.0 {
+                0.0
+            } else {
+                inter * g.estimate() / (a.estimate() * b.estimate())
+            }
         });
 
     Ok(Json(json!({

--- a/crates/cubism-serve/src/lib.rs
+++ b/crates/cubism-serve/src/lib.rs
@@ -26,9 +26,9 @@ pub mod store;
 pub use series::{SeriesState, series_router};
 pub use store::{CubeStore, StoreError};
 
+use axum::Router;
 use axum::response::Html;
 use axum::routing::get;
-use axum::Router;
 use std::sync::Arc;
 
 const DASHBOARD: &str = include_str!("../assets/index.html");
@@ -64,7 +64,11 @@ async fn serve_inner(
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
     println!(
         "serving {cells} cells at http://127.0.0.1:{port}{}",
-        if has_series { " (with /api/series)" } else { "" }
+        if has_series {
+            " (with /api/series)"
+        } else {
+            ""
+        }
     );
     axum::serve(listener, app).await
 }
@@ -75,6 +79,10 @@ pub async fn serve(store: CubeStore, port: u16) -> std::io::Result<()> {
 }
 
 /// Same as [`serve`], plus `/api/series` backed by `series`.
-pub async fn serve_with_series(store: CubeStore, series: SeriesState, port: u16) -> std::io::Result<()> {
+pub async fn serve_with_series(
+    store: CubeStore,
+    series: SeriesState,
+    port: u16,
+) -> std::io::Result<()> {
     serve_inner(Arc::new(store), Some(Arc::new(series)), port).await
 }

--- a/crates/cubism-serve/src/series.rs
+++ b/crates/cubism-serve/src/series.rs
@@ -47,13 +47,15 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
-use cubism_core::{AggKind, CubeSpec, EventTime, FixedResolution, Resolution, WindowId, WindowRevision, XUnit};
+use cubism_core::{
+    AggKind, CubeSpec, EventTime, FixedResolution, Resolution, WindowId, WindowRevision, XUnit,
+};
 use cubism_datafusion::temporal_build::{measure_column_name, temporal_state_schema};
 use cubism_datafusion::{CoveragePlan, GapPolicy, ResolutionPlan, SeriesResponse, TemporalQuery};
 use cubism_iceberg::config::open_catalog;
 use cubism_iceberg::{AggregateReader, CatalogConfig, PublicationStore, TemporalTable};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::api::ApiError;
 
@@ -97,7 +99,12 @@ impl SeriesState {
         let catalog = open_catalog(catalog_config).await?;
         let schema = temporal_state_schema(&spec)?;
         let table = TemporalTable::create(catalog.as_ref(), &spec.name, &schema).await?;
-        Ok(Self { catalog, table, publications, spec })
+        Ok(Self {
+            catalog,
+            table,
+            publications,
+            spec,
+        })
     }
 }
 
@@ -156,8 +163,10 @@ async fn series(
     State(state): State<Arc<SeriesState>>,
     Json(req): Json<SeriesRequest>,
 ) -> Result<Json<Value>, ApiError> {
-    let selector: XUnit =
-        req.selector.parse().map_err(|e| ApiError::bad_request(format!("bad selector: {e}")))?;
+    let selector: XUnit = req
+        .selector
+        .parse()
+        .map_err(|e| ApiError::bad_request(format!("bad selector: {e}")))?;
 
     let measure = state
         .spec
@@ -179,11 +188,9 @@ async fn series(
 
     // Checked in `SeriesState::open`, but a spec is mutable state this
     // handler doesn't own — re-check rather than trust construction-time.
-    let temporal_spec = state
-        .spec
-        .temporal
-        .as_ref()
-        .ok_or_else(|| ApiError::bad_request(format!("cube '{}' has no temporal spec", state.spec.name)))?;
+    let temporal_spec = state.spec.temporal.as_ref().ok_or_else(|| {
+        ApiError::bad_request(format!("cube '{}' has no temporal spec", state.spec.name))
+    })?;
 
     let resolution = req
         .resolution
@@ -207,7 +214,8 @@ async fn series(
     )
     .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
-    let plan = ResolutionPlan::new(&query, temporal_spec).map_err(|e| ApiError::bad_request(e.to_string()))?;
+    let plan = ResolutionPlan::new(&query, temporal_spec)
+        .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     // Assign each request-supplied window to the one segment whose range
     // contains its bucket_start (see the module doc comment), resolving its
@@ -221,8 +229,9 @@ async fn series(
             if !segment.range.contains(bucket_start) {
                 continue;
             }
-            let window_id = WindowId::new(w.window_id.clone())
-                .map_err(|e| ApiError::bad_request(format!("bad window_id '{}': {e}", w.window_id)))?;
+            let window_id = WindowId::new(w.window_id.clone()).map_err(|e| {
+                ApiError::bad_request(format!("bad window_id '{}': {e}", w.window_id))
+            })?;
             let current = state
                 .publications
                 .current(&state.table.cube_id, &window_id)
@@ -253,9 +262,15 @@ async fn series(
         batches.push(segment_batches);
     }
 
-    let response =
-        SeriesResponse::new(&coverage, gap_policy, measure.agg, &column, &[selector], &batches)
-            .map_err(|e| ApiError::bad_request(e.to_string()))?;
+    let response = SeriesResponse::new(
+        &coverage,
+        gap_policy,
+        measure.agg,
+        &column,
+        &[selector],
+        &batches,
+    )
+    .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     Ok(Json(json!({
         "cube": state.spec.name,
@@ -276,5 +291,7 @@ async fn series(
 }
 
 pub fn series_router(state: Arc<SeriesState>) -> Router {
-    Router::new().route("/api/series", post(series)).with_state(state)
+    Router::new()
+        .route("/api/series", post(series))
+        .with_state(state)
 }

--- a/crates/cubism-serve/src/store.rs
+++ b/crates/cubism-serve/src/store.rs
@@ -6,7 +6,7 @@
 //! magic bytes of their versioned formats — the store needs no spec.
 
 use cubism_core::sketch::{Centroid, ExemplarSample, KmvSketch, TopK};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::{BTreeSet, HashMap};
 
 #[derive(Debug, thiserror::Error)]
@@ -95,7 +95,11 @@ impl CubeStore {
             ));
         }
 
-        let index = xunits.iter().enumerate().map(|(i, x)| (x.clone(), i)).collect();
+        let index = xunits
+            .iter()
+            .enumerate()
+            .map(|(i, x)| (x.clone(), i))
+            .collect();
 
         let mut dimensions: BTreeSet<String> = BTreeSet::new();
         for xunit in &xunits {
@@ -151,25 +155,32 @@ impl CubeStore {
     }
 
     pub fn sketch_kind(&self, measure: &str) -> Option<SketchKind> {
-        self.sketches.iter().find(|(n, _)| n == measure).map(|(_, k)| *k)
+        self.sketches
+            .iter()
+            .find(|(n, _)| n == measure)
+            .map(|(_, k)| *k)
     }
 
     /// Decode one sketch blob into a JSON summary (never the raw bytes).
     pub fn decode_sketch(&self, measure: &str, row: usize) -> Value {
-        let Some(blob) = self.blob(measure, row) else { return Value::Null };
+        let Some(blob) = self.blob(measure, row) else {
+            return Value::Null;
+        };
         match SketchKind::detect(blob) {
-            SketchKind::Kmv => KmvSketch::from_bytes(blob).map_or(Value::Null, |s| {
-                json!({"kind": "kmv", "estimate": s.estimate(), "k": s.k()})
-            }),
-            SketchKind::TopK => TopK::from_bytes(blob).map_or(Value::Null, |t| {
-                json!({"kind": "top_k", "items": t.top()})
-            }),
-            SketchKind::Sample => ExemplarSample::from_bytes(blob).map_or(Value::Null, |s| {
-                json!({"kind": "sample", "values": s.values().collect::<Vec<_>>()})
-            }),
-            SketchKind::Centroid => Centroid::from_bytes(blob).map_or(Value::Null, |c| {
-                json!({"kind": "centroid", "dim": c.dim(), "mean": c.mean()})
-            }),
+            SketchKind::Kmv => KmvSketch::from_bytes(blob).map_or(
+                Value::Null,
+                |s| json!({"kind": "kmv", "estimate": s.estimate(), "k": s.k()}),
+            ),
+            SketchKind::TopK => TopK::from_bytes(blob)
+                .map_or(Value::Null, |t| json!({"kind": "top_k", "items": t.top()})),
+            SketchKind::Sample => ExemplarSample::from_bytes(blob).map_or(
+                Value::Null,
+                |s| json!({"kind": "sample", "values": s.values().collect::<Vec<_>>()}),
+            ),
+            SketchKind::Centroid => Centroid::from_bytes(blob).map_or(
+                Value::Null,
+                |c| json!({"kind": "centroid", "dim": c.dim(), "mean": c.mean()}),
+            ),
             SketchKind::Unknown => Value::Null,
         }
     }
@@ -182,9 +193,7 @@ impl CubeStore {
             .iter()
             .enumerate()
             .filter(|(_, x)| {
-                x.starts_with(&prefix)
-                    && !x.contains(',')
-                    && x.matches('=').count() == depth
+                x.starts_with(&prefix) && !x.contains(',') && x.matches('=').count() == depth
             })
             .map(|(i, _)| i)
             .collect()
@@ -197,7 +206,11 @@ impl CubeStore {
             .split('/')
             .filter_map(|seg| seg.split_once('=').map(|(_, v)| v))
             .collect();
-        if values.is_empty() { xunit.clone() } else { values.join(" / ") }
+        if values.is_empty() {
+            xunit.clone()
+        } else {
+            values.join(" / ")
+        }
     }
 }
 
@@ -207,7 +220,11 @@ fn append_strings(out: &mut Vec<String>, col: &arrow::array::ArrayRef) -> Result
         .as_string_opt::<i32>()
         .ok_or_else(|| StoreError::Shape(format!("xunit column is {}", col.data_type())))?;
     for i in 0..arr.len() {
-        out.push(if arr.is_null(i) { String::new() } else { arr.value(i).to_string() });
+        out.push(if arr.is_null(i) {
+            String::new()
+        } else {
+            arr.value(i).to_string()
+        });
     }
     Ok(())
 }
@@ -235,19 +252,31 @@ fn append_values(out: &mut Vec<Value>, col: &arrow::array::ArrayRef) -> Result<(
         DataType::Int64 => {
             let arr = col.as_primitive::<Int64Type>();
             for i in 0..arr.len() {
-                out.push(if arr.is_null(i) { Value::Null } else { json!(arr.value(i)) });
+                out.push(if arr.is_null(i) {
+                    Value::Null
+                } else {
+                    json!(arr.value(i))
+                });
             }
         }
         DataType::UInt64 => {
             let arr = col.as_primitive::<UInt64Type>();
             for i in 0..arr.len() {
-                out.push(if arr.is_null(i) { Value::Null } else { json!(arr.value(i)) });
+                out.push(if arr.is_null(i) {
+                    Value::Null
+                } else {
+                    json!(arr.value(i))
+                });
             }
         }
         DataType::Float64 => {
             let arr = col.as_primitive::<Float64Type>();
             for i in 0..arr.len() {
-                out.push(if arr.is_null(i) { Value::Null } else { json!(arr.value(i)) });
+                out.push(if arr.is_null(i) {
+                    Value::Null
+                } else {
+                    json!(arr.value(i))
+                });
             }
         }
         DataType::Utf8 => {
@@ -280,7 +309,9 @@ fn append_values(out: &mut Vec<Value>, col: &arrow::array::ArrayRef) -> Result<(
             }
         }
         other => {
-            return Err(StoreError::Shape(format!("unsupported measure column type {other}")));
+            return Err(StoreError::Shape(format!(
+                "unsupported measure column type {other}"
+            )));
         }
     }
     Ok(())

--- a/crates/cubism-serve/tests/api.rs
+++ b/crates/cubism-serve/tests/api.rs
@@ -48,7 +48,9 @@ async fn cube_file(dir: &tempfile::TempDir) -> String {
     let batch = RecordBatch::try_new(
         schema,
         vec![
-            Arc::new(StringArray::from(vec!["Bash", "Bash", "Bash", "Read", "Read"])),
+            Arc::new(StringArray::from(vec![
+                "Bash", "Bash", "Bash", "Read", "Read",
+            ])),
             Arc::new(StringArray::from(vec!["ok", "error", "ok", "ok", "error"])),
             Arc::new(Int64Array::from(vec![10, 20, 30, 40, 50])),
             Arc::new(StringArray::from(vec!["s1", "s1", "s2", "s2", "s3"])),
@@ -60,8 +62,15 @@ async fn cube_file(dir: &tempfile::TempDir) -> String {
     ctx.register_batch("events", batch).unwrap();
     let spec = CubeSpec::from_yaml(SPEC).unwrap();
     let (df, _dict) = build_cube(&ctx, &spec, "events").await.unwrap();
-    let path = dir.path().join("cube.parquet").to_str().unwrap().to_string();
-    df.write_parquet(&path, DataFrameWriteOptions::new(), None).await.unwrap();
+    let path = dir
+        .path()
+        .join("cube.parquet")
+        .to_str()
+        .unwrap()
+        .to_string();
+    df.write_parquet(&path, DataFrameWriteOptions::new(), None)
+        .await
+        .unwrap();
     path
 }
 
@@ -70,7 +79,9 @@ async fn get(base: &str, path: &str) -> (u16, Value) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let mut stream = tokio::net::TcpStream::connect(base).await.unwrap();
     stream
-        .write_all(format!("GET {path} HTTP/1.1\r\nHost: {base}\r\nConnection: close\r\n\r\n").as_bytes())
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: {base}\r\nConnection: close\r\n\r\n").as_bytes(),
+        )
         .await
         .unwrap();
     let mut buf = Vec::new();
@@ -116,8 +127,11 @@ async fn api_end_to_end() {
 
     // set ops: sessions(Bash) = {s1,s2}, sessions(error) = {s1,s3};
     // exact while under-full: |A∩B| = 1, |A∪B| = 3
-    let (status, ops) =
-        get(&base, "/api/setops?a=/tool/tool=Bash&b=/outcome/outcome=error").await;
+    let (status, ops) = get(
+        &base,
+        "/api/setops?a=/tool/tool=Bash&b=/outcome/outcome=error",
+    )
+    .await;
     assert_eq!(status, 200);
     assert_eq!(ops["measure"], "sessions");
     assert_eq!(ops["a"]["estimate"], 2.0);
@@ -145,7 +159,13 @@ async fn api_end_to_end() {
     // panel exists in the served page, not that the JS renders.
     let (status, page) = get_text(&base, "/").await;
     assert_eq!(status, 200);
-    for token in ["id=\"tsPanel\"", "id=\"tsChart\"", "/api/series", "bucket_start", "is_exact"] {
+    for token in [
+        "id=\"tsPanel\"",
+        "id=\"tsChart\"",
+        "/api/series",
+        "bucket_start",
+        "is_exact",
+    ] {
         assert!(page.contains(token), "dashboard must contain {token}");
     }
 }
@@ -156,12 +176,17 @@ async fn get_text(base: &str, path: &str) -> (u16, String) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     let mut stream = tokio::net::TcpStream::connect(base).await.unwrap();
     stream
-        .write_all(format!("GET {path} HTTP/1.1\r\nHost: {base}\r\nConnection: close\r\n\r\n").as_bytes())
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: {base}\r\nConnection: close\r\n\r\n").as_bytes(),
+        )
         .await
         .unwrap();
     let mut buf = Vec::new();
     stream.read_to_end(&mut buf).await.unwrap();
     let text = String::from_utf8(buf).unwrap();
     let status: u16 = text.split_whitespace().nth(1).unwrap().parse().unwrap();
-    (status, text.split("\r\n\r\n").nth(1).unwrap_or("").to_string())
+    (
+        status,
+        text.split("\r\n\r\n").nth(1).unwrap_or("").to_string(),
+    )
 }

--- a/crates/cubism-serve/tests/series.rs
+++ b/crates/cubism-serve/tests/series.rs
@@ -20,22 +20,34 @@
 
 use chrono::DateTime;
 use cubism_core::encoding::canonical_xunit_content_id;
-use cubism_core::temporal::{AllowedLateness, BucketOrigin, FixedResolution, Resolution, TemporalSpec, WindowId, WindowRevision};
-use cubism_core::{AggKind, AggregateState, AggregateStateConfig, AverageState, CanonicalXUnit, CubeSpec, MeasureSpec, XUnit};
-use cubism_iceberg::config::open_catalog;
-use cubism_iceberg::{AggregateWriter, AppendWindow, CatalogConfig, ClaimResult, PublicationStore, TemporalTable};
+use cubism_core::temporal::{
+    AllowedLateness, BucketOrigin, FixedResolution, Resolution, TemporalSpec, WindowId,
+    WindowRevision,
+};
+use cubism_core::{
+    AggKind, AggregateState, AggregateStateConfig, AverageState, CanonicalXUnit, CubeSpec,
+    MeasureSpec, XUnit,
+};
 use cubism_datafusion::datafusion::arrow::array::{
     BinaryArray, FixedSizeBinaryArray, Int64Array, RecordBatch, TimestampMicrosecondArray,
 };
-use cubism_datafusion::datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, TimeUnit};
-use serde_json::{json, Value};
+use cubism_datafusion::datafusion::arrow::datatypes::{
+    DataType, Field, Schema as ArrowSchema, TimeUnit,
+};
+use cubism_iceberg::config::open_catalog;
+use cubism_iceberg::{
+    AggregateWriter, AppendWindow, CatalogConfig, ClaimResult, PublicationStore, TemporalTable,
+};
+use serde_json::{Value, json};
 use std::sync::Arc;
 use tempfile::TempDir;
 
 const CUBE_ID: &str = "series_e2e";
 
 fn micros(timestamp: &str) -> i64 {
-    DateTime::parse_from_rfc3339(timestamp).unwrap().timestamp_micros()
+    DateTime::parse_from_rfc3339(timestamp)
+        .unwrap()
+        .timestamp_micros()
 }
 
 /// The real global-rollup `XUnitContentId`, computed the same two calls
@@ -45,7 +57,9 @@ fn micros(timestamp: &str) -> i64 {
 /// byte-identical id to what a real build would write, not arbitrary
 /// sentinel bytes, or `SeriesResponse`'s selector filter drops every row.
 fn global_content_id() -> [u8; 32] {
-    *canonical_xunit_content_id(&CanonicalXUnit::from(&XUnit::global())).unwrap().as_bytes()
+    *canonical_xunit_content_id(&CanonicalXUnit::from(&XUnit::global()))
+        .unwrap()
+        .as_bytes()
 }
 
 fn avg_states_schema() -> ArrowSchema {
@@ -61,8 +75,9 @@ fn avg_states_schema() -> ArrowSchema {
 }
 
 fn avg_states_batch(rows: &[(&str, [u8; 32], Vec<u8>)]) -> RecordBatch {
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _)| *x)).unwrap();
     let avg = BinaryArray::from_iter_values(rows.iter().map(|(_, _, blob)| blob.as_slice()));
     RecordBatch::try_new(
@@ -145,8 +160,9 @@ fn count_states_schema() -> ArrowSchema {
 }
 
 fn count_states_batch(rows: &[(&str, [u8; 32], i64)]) -> RecordBatch {
-    let bucket_start = TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _)| micros(t)))
-        .with_timezone("+00:00");
+    let bucket_start =
+        TimestampMicrosecondArray::from_iter_values(rows.iter().map(|(t, _, _)| micros(t)))
+            .with_timezone("+00:00");
     let xunit_id = FixedSizeBinaryArray::try_from_iter(rows.iter().map(|(_, x, _)| *x)).unwrap();
     let views = Int64Array::from_iter_values(rows.iter().map(|(_, _, v)| *v));
     RecordBatch::try_new(
@@ -177,17 +193,24 @@ async fn post(base: &str, path: &str, body: &Value) -> (u16, Value) {
     let text = String::from_utf8(buf).unwrap();
     let status: u16 = text.split_whitespace().nth(1).unwrap().parse().unwrap();
     let resp_body = text.split("\r\n\r\n").nth(1).unwrap_or("");
-    (status, serde_json::from_str(resp_body).unwrap_or(Value::Null))
+    (
+        status,
+        serde_json::from_str(resp_body).unwrap_or(Value::Null),
+    )
 }
 
 #[tokio::test]
-async fn series_endpoint_answers_an_aligned_two_window_range_and_reports_an_unknown_window_as_missing() {
+async fn series_endpoint_answers_an_aligned_two_window_range_and_reports_an_unknown_window_as_missing()
+ {
     let warehouse = TempDir::new().unwrap();
     let catalog_dir = TempDir::new().unwrap();
     let catalog_db = catalog_dir.path().join("catalog.sqlite");
     let control_dir = TempDir::new().unwrap();
     let control_db = control_dir.path().join("control.sqlite");
-    let config = CatalogConfig::Sqlite { warehouse: warehouse.path().to_path_buf(), catalog_db: catalog_db.clone() };
+    let config = CatalogConfig::Sqlite {
+        warehouse: warehouse.path().to_path_buf(),
+        catalog_db: catalog_db.clone(),
+    };
 
     let cube_spec = spec(day_spec());
 
@@ -208,18 +231,27 @@ async fn series_endpoint_answers_an_aligned_two_window_range_and_reports_an_unkn
     // durable state, not something wired to the same in-process objects.
     {
         let catalog = open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &avg_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &avg_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
 
         let global_id = global_content_id();
-        for (window, bucket_ts, state) in
-            [(&w1, "2026-08-13T12:00:00Z", &a), (&w2, "2026-08-14T12:00:00Z", &b)]
-        {
+        for (window, bucket_ts, state) in [
+            (&w1, "2026-08-13T12:00:00Z", &a),
+            (&w2, "2026-08-14T12:00:00Z", &b),
+        ] {
             let states = vec![avg_states_batch(&[(bucket_ts, global_id, state.encode())])];
             let registry = vec![registry_batch(&[(global_id, b"/G")])];
             let expected_rows: u64 = states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
             let claim = publications
-                .claim_run(CUBE_ID, window, &format!("run-{}", window.as_str()), revision, expected_rows)
+                .claim_run(
+                    CUBE_ID,
+                    window,
+                    &format!("run-{}", window.as_str()),
+                    revision,
+                    expected_rows,
+                )
                 .await
                 .unwrap();
             assert!(matches!(claim, ClaimResult::New(_)));
@@ -236,13 +268,21 @@ async fn series_endpoint_answers_an_aligned_two_window_range_and_reports_an_unkn
             )
             .await
             .unwrap();
-            publications.record_append(&format!("run-{}", window.as_str()), result.snapshot_id).await.unwrap();
-            publications.publish(&format!("run-{}", window.as_str()), None).await.unwrap();
+            publications
+                .record_append(&format!("run-{}", window.as_str()), result.snapshot_id)
+                .await
+                .unwrap();
+            publications
+                .publish(&format!("run-{}", window.as_str()), None)
+                .await
+                .unwrap();
         }
     }
 
     let series_publications = PublicationStore::sqlite(&control_db).await.unwrap();
-    let state = cubism_serve::SeriesState::open(cube_spec, &config, series_publications).await.unwrap();
+    let state = cubism_serve::SeriesState::open(cube_spec, &config, series_publications)
+        .await
+        .unwrap();
     let app = cubism_serve::series_router(Arc::new(state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base = listener.local_addr().unwrap().to_string();
@@ -323,7 +363,10 @@ async fn series_endpoint_answers_a_count_measure_by_summing_the_published_window
     let catalog_db = catalog_dir.path().join("catalog.sqlite");
     let control_dir = TempDir::new().unwrap();
     let control_db = control_dir.path().join("control.sqlite");
-    let config = CatalogConfig::Sqlite { warehouse: warehouse.path().to_path_buf(), catalog_db: catalog_db.clone() };
+    let config = CatalogConfig::Sqlite {
+        warehouse: warehouse.path().to_path_buf(),
+        catalog_db: catalog_db.clone(),
+    };
 
     let w1 = WindowId::new("2026-08-13").unwrap();
     let w2 = WindowId::new("2026-08-14").unwrap();
@@ -331,17 +374,27 @@ async fn series_endpoint_answers_a_count_measure_by_summing_the_published_window
 
     {
         let catalog = open_catalog(&config).await.unwrap();
-        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &count_states_schema()).await.unwrap();
+        let table = TemporalTable::create(catalog.as_ref(), CUBE_ID, &count_states_schema())
+            .await
+            .unwrap();
         let publications = PublicationStore::sqlite(&control_db).await.unwrap();
 
         let global_id = global_content_id();
-        for (window, bucket_ts, views) in [(&w1, "2026-08-13T12:00:00Z", 3i64), (&w2, "2026-08-14T12:00:00Z", 4)]
-        {
+        for (window, bucket_ts, views) in [
+            (&w1, "2026-08-13T12:00:00Z", 3i64),
+            (&w2, "2026-08-14T12:00:00Z", 4),
+        ] {
             let states = vec![count_states_batch(&[(bucket_ts, global_id, views)])];
             let registry = vec![registry_batch(&[(global_id, b"/G")])];
             let expected_rows: u64 = states.iter().map(RecordBatch::num_rows).sum::<usize>() as u64;
             let claim = publications
-                .claim_run(CUBE_ID, window, &format!("run-{}", window.as_str()), revision, expected_rows)
+                .claim_run(
+                    CUBE_ID,
+                    window,
+                    &format!("run-{}", window.as_str()),
+                    revision,
+                    expected_rows,
+                )
                 .await
                 .unwrap();
             assert!(matches!(claim, ClaimResult::New(_)));
@@ -358,13 +411,22 @@ async fn series_endpoint_answers_a_count_measure_by_summing_the_published_window
             )
             .await
             .unwrap();
-            publications.record_append(&format!("run-{}", window.as_str()), result.snapshot_id).await.unwrap();
-            publications.publish(&format!("run-{}", window.as_str()), None).await.unwrap();
+            publications
+                .record_append(&format!("run-{}", window.as_str()), result.snapshot_id)
+                .await
+                .unwrap();
+            publications
+                .publish(&format!("run-{}", window.as_str()), None)
+                .await
+                .unwrap();
         }
     }
 
     let series_publications = PublicationStore::sqlite(&control_db).await.unwrap();
-    let state = cubism_serve::SeriesState::open(count_spec(day_spec()), &config, series_publications).await.unwrap();
+    let state =
+        cubism_serve::SeriesState::open(count_spec(day_spec()), &config, series_publications)
+            .await
+            .unwrap();
     let app = cubism_serve::series_router(Arc::new(state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base = listener.local_addr().unwrap().to_string();
@@ -388,7 +450,11 @@ async fn series_endpoint_answers_a_count_measure_by_summing_the_published_window
     let points = body["points"].as_array().unwrap();
     assert_eq!(points.len(), 1);
     assert_eq!(points[0]["is_exact"], true);
-    assert_eq!(points[0]["value"], json!(7.0), "3 + 4 across both windows' rows");
+    assert_eq!(
+        points[0]["value"],
+        json!(7.0),
+        "3 + 4 across both windows' rows"
+    );
     assert_eq!(points[0]["published"].as_array().unwrap().len(), 2);
     assert_eq!(points[0]["missing"].as_array().unwrap().len(), 0);
 

--- a/crates/cubism-timeseries-bench/examples/explain_aggregate.rs
+++ b/crates/cubism-timeseries-bench/examples/explain_aggregate.rs
@@ -99,7 +99,9 @@ async fn main() -> Result<()> {
     }
 
     println!("=== EXPLAIN (logical + verbose physical plan) ===");
-    let df = context.sql(&format!("EXPLAIN VERBOSE {AGGREGATE_SQL}")).await?;
+    let df = context
+        .sql(&format!("EXPLAIN VERBOSE {AGGREGATE_SQL}"))
+        .await?;
     df.show().await?;
 
     Ok(())

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# cargo-deny config for the nightly dependency/license/security scan
+# (.github/workflows/nightly.yml, #43's "dependency, license, and security
+# scanning with an explicit remediation policy" workstream).
+#
+# Remediation policy: nightly failures here do not block PR merges (they
+# aren't a required check). A failing advisory or license gets triaged the
+# next business day by whoever is on the #43 rotation at the time; if a
+# finding needs more than a version bump, file a follow-up issue referencing
+# the advisory/license ID and `# allow`-annotate the specific entry below
+# with that issue number rather than silently loosening the policy.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ ignore = []
 version = 2
 allow = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "MIT",
     "BSD-2-Clause",
     "BSD-3-Clause",
@@ -33,6 +34,12 @@ allow = [
     "OpenSSL",
 ]
 confidence-threshold = 0.8
+
+# libbz2-rs-sys reports its `license` field as the non-SPDX string
+# "bzip2-1.0.6" (a real permissive license, just not expressed as SPDX) —
+# this will likely need a `[[licenses.clarify]]` entry on nightly's first
+# run rather than an `allow` addition. Left for that run to surface rather
+# than guessed at here (see the remediation policy above).
 
 [bans]
 multiple-versions = "warn"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

First two workstreams of #43: pin the toolchain, add a required PR gate, and split the slow/optional stuff into a non-blocking nightly workflow. The rest of #43's checklist (integration matrix beyond what `cargo test --workspace` already runs, merge-law property tests, perf baselines with thresholds, deeper dependency remediation) stays open on the epic — this PR is the merge gate, not the full plan.

- `rust-toolchain.toml` pins 1.96.1 (rustfmt + clippy components), and normalizes the whole tree under it — retires the recurring format-drift tax tracked as `#3` (`docs/sdlc-process-notes.md`). Also fixes 4 broken/private rustdoc intra-doc links so `cargo doc` passes clean under `-D warnings` from the start.
- `.github/workflows/ci.yml` — required on PRs into `main` and pushes to `main`: fmt, clippy (`-D warnings`), `cargo test --workspace --all-targets` + `--doc`, docs (`-D warnings`), and a Python-bindings build+import smoke (no pytest suite exists yet for `bindings/cubism-py`). A `ci-required` aggregator job gives branch protection one status check to depend on.
- `.github/workflows/nightly.yml` — schedule + `workflow_dispatch`, **not required**: `cargo-deny` (licenses/advisories/bans/sources via `deny.toml`), the `#[ignore]`'d 1M-row benchmark-digest test, and the standalone `spark-adapter` sbt suite (not a Cargo workspace member; #43 explicitly separates it out as optional/external).
- `deny.toml` — license allow-list + an explicit remediation note (nightly failures triage the next business day; loosen via a documented exception, not silently).
- `README.md` — a Development section with the exact commands CI runs, so required vs. nightly doesn't have to be reverse-engineered from YAML.

## Verified

Locally (rustc/cargo 1.96.1) and now confirmed on this PR's own CI run (`gh pr checks 58`, all 6 jobs green — fmt 13s, clippy 3m, test 7m, docs 2m, python 4m23s):

- `cargo fmt --all --check` — clean (after the one-time normalization in this branch)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test --workspace --all-targets -- --list`: 250 tests, 2 `#[ignore]`d (one is the nightly benchmark-digest test, the other is an existing retry-loop timing test unrelated to this PR)
- `cargo test --workspace --doc`: 1 doctest passes across 7 crates — added as a step since `--all-targets` doesn't cover doctests
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — clean after the 4 doc-link fixes

## Not in this PR

- **Branch protection isn't a file** — it's a repo-admin API call. Now that this PR's `ci-required` check has run, the follow-up is:
  ```
  gh api -X PUT repos/jeromebanks/cubism-rs/branches/main/protection \
    -F required_status_checks.strict=true \
    -f 'required_status_checks.contexts[]=CI required checks' \
    -F enforce_admins=true \
    -F required_pull_request_reviews=null \
    -F restrictions=null
  ```
  (`-F`, not `-f`, on `strict`/`enforce_admins`/the two `null`s — `-f` sends everything as a string and the API rejects a string where it expects a JSON boolean/null.) Flagging here rather than running it unprompted.
- A deploy/publish workflow — that's #48 (release engineering), a different epic.

## Test plan

- [x] This PR's own `ci-required` check went green, exercising the gate on a real diff (per `docs/sdlc-process-notes.md`'s "the only real verification is a PR" lesson) — caught and fixed a real bug (`dtolnay/rust-toolchain@master` needs an explicit `toolchain` input; it doesn't read `rust-toolchain.toml` on its own) that no amount of local testing would have surfaced.
- [ ] Nightly workflow gets a manual `workflow_dispatch` run once merged, to confirm cargo-deny/sbt/bench-smoke actually work end to end (unverified locally — no `cargo-deny`/`sbt` installed in this environment)

Closes the first two checklist items of #43; leaves the rest open.
