### PR TITLE
ci: add example-spec and internal-link validation to required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI
 
 # Required pre-merge gate for #43: every PR into main, and every push to
 # main (post-merge signal), runs fmt/clippy/test/docs against the pinned
-# toolchain in rust-toolchain.toml, plus a build+import smoke test for the
-# Python bindings. See docs/sdlc-process-notes.md for why fmt/docs are
-# gated with warnings-as-errors from the start rather than added loose and
+# toolchain in rust-toolchain.toml, example-spec validation, an internal
+# markdown link check, and a build+import smoke test for the Python
+# bindings. See docs/sdlc-process-notes.md for why fmt/docs are gated
+# with warnings-as-errors from the start rather than added loose and
 # tightened later.
 #
 # Slow/optional suites (cargo-deny, the Scala Spark adapter, benchmark
@@ -81,6 +82,44 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
+  spec-validate:
+    name: spec validation (examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p cubism-cli
+      - name: validate every example cube spec
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          specs=(examples/*.yaml examples/web_analytics_demo/*.yaml)
+          for spec in "${specs[@]}"; do
+            echo "== $spec =="
+            ./target/debug/cubism validate "$spec"
+          done
+
+  links:
+    name: link check (internal, README + docs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: lychee (offline — internal/relative links + fragments only)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --offline: never hits the network, so this stays fast and
+          # deterministic enough to be a required check (external-link
+          # rot goes to nightly.yml instead, per #43's remediation
+          # pattern in deny.toml). --include-fragments catches broken
+          # in-page section links like docs/TIMESERIES_ROADMAP.md's.
+          args: >-
+            --offline --include-fragments --no-progress
+            README.md 'docs/**/*.md'
+          fail: true
+
   python:
     name: python bindings
     runs-on: ubuntu-latest
@@ -111,7 +150,7 @@ jobs:
   ci-required:
     name: CI required checks
     if: always()
-    needs: [fmt, clippy, test, docs, python]
+    needs: [fmt, clippy, test, docs, spec-validate, links, python]
     runs-on: ubuntu-latest
     steps:
       - name: Check all required jobs succeeded

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-targets
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+cargo build -p cubism-cli && for f in examples/*.yaml examples/web_analytics_demo/*.yaml; do
+  ./target/debug/cubism validate "$f"
+done                                                 # every example spec still validates
+lychee --offline --include-fragments README.md 'docs/**/*.md'  # internal links + anchors
 cd bindings/cubism-py && maturin build --out dist   # python bindings build smoke
 ```
 

--- a/docs/TIMESERIES_FEASIBILITY.md
+++ b/docs/TIMESERIES_FEASIBILITY.md
@@ -4,8 +4,8 @@ Status: design proposal, not implemented
 
 Evaluated: 2026-07-28
 
-Extends: the workspace-root [`PLAN.md`](../../PLAN.md); it does not replace that
-plan
+Extends: the workspace-root `PLAN.md` (private planning doc, outside this repo);
+it does not replace that plan
 
 ## Executive conclusion
 

--- a/docs/TIMESERIES_IMPLEMENTATION_PLAN.md
+++ b/docs/TIMESERIES_IMPLEMENTATION_PLAN.md
@@ -33,8 +33,8 @@ folded into the roadmap's done-fraction.
 
 Depends on: [`TIMESERIES_FEASIBILITY.md`](TIMESERIES_FEASIBILITY.md)
 
-Extends: the workspace-root [`PLAN.md`](../../PLAN.md); it does not overwrite or
-invalidate the existing static-cube plan
+Extends: the workspace-root `PLAN.md` (private planning doc, outside this repo);
+it does not overwrite or invalidate the existing static-cube plan
 
 ## Outcome and delivery principles
 


### PR DESCRIPTION
## Summary
- Closes #60 — the "link/schema validation" half of #43's checklist that #58 left uncovered.
- `spec-validate` job: runs the existing `cubism validate` over every example cube spec (`examples/*.yaml`, `examples/web_analytics_demo/*.yaml`) — not a new JSON Schema, per the issue's own note that the validator already covers this.
- `links` job: `lychee-action`, `--offline --include-fragments` against `README.md` + `docs/**/*.md` (internal/relative links + in-page anchors only, no network calls) — kept fast/deterministic enough to be a required check. External-link checking is deliberately out of scope (issue called it optional/nightly-only); left for a future nightly job if ever wanted.
- Both jobs added to `ci-required`'s `needs`.
- README's "Development" section updated with the two new local-repro commands.
- Bonus fix: the new `links` job caught two dead `PLAN.md` links in `docs/TIMESERIES_FEASIBILITY.md` / `docs/TIMESERIES_IMPLEMENTATION_PLAN.md` (pointing outside this repo entirely) — a known open item from `docs/TIMESERIES_PHASE_35_HANDOFF.md` #5 that was never fixed. Rewrote both to prose.

## Test plan
- [x] Built `cubism-cli` locally and ran `validate` on all 6 example specs — all pass
- [x] Installed `lychee` locally and ran the exact check args — 0 errors
- [x] Verified it actually catches breakage: injected a broken relative link + bad anchor, lychee flagged both, then reverted
- [x] `actionlint` clean on the updated workflow
- [x] Watched the real GitHub Actions run on this PR — all 8 required jobs pass, including the new `spec-validate` and `links` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2KqcNerEZqjFo9AaGNCJ3