### PR TITLE
fix: repair lost line-continuation whitespace in checksum error message

### DIFF
--- a/crates/cubism-core/src/aggregate_state.rs
+++ b/crates/cubism-core/src/aggregate_state.rs
@@ -239,7 +239,9 @@ fn verify_framing<'a>(bytes: &'a [u8], kind: &str) -> Result<&'a [u8], CubismErr
             let actual = crc32fast::hash(body);
             if stored != actual {
                 return Err(CubismError::AggregateState(format!(
-                    "{kind} state blob failed its checksum: stored {stored:#010x},                      computed {actual:#010x} — the blob is corrupt, not merely                      an unknown version"
+                    "{kind} state blob failed its checksum: stored {stored:#010x}, \
+                     computed {actual:#010x} — the blob is corrupt, not merely \
+                     an unknown version"
                 )));
             }
             Ok(body)


### PR DESCRIPTION
## Summary
- `crates/cubism-core/src/aggregate_state.rs:242` had two ~22-space literal runs where a `\` line continuation had been lost — the checksum-failure `CubismError` text rendered with garbled double-width gaps instead of single spaces.
- Restructured as a multi-line string with `\` continuation, matching the existing style in `crates/cubism-correct/src/windows.rs:140-143`, so a future single-line collapse is less likely to reintroduce the same defect.
- Grepped the workspace for the same lost-continuation pattern (4+ consecutive spaces inside a string literal) and confirmed this was the only real occurrence — the other two matches (`cubism-datafusion/src/build.rs`) are legitimate embedded-YAML test fixtures, not the same bug.

Closes #55

**This PR is the first execution of the repo's new `.claude/skills/work-issue/` skill** (ported from `~/dev/postscript_interpreter`'s equivalent, ~SDLC.md`'s policy) — the extra verification below is proportionate to that, not to the size of the change.

## Test plan
- [x] Rendered the fixed literal through a standalone `rustc` compile with representative values — confirmed single-space output (`stored 0xdeadbeef, computed 0xcafebabe — the blob is corrupt, not merely an unknown version`), since "the literal looks right" and "the literal renders right" are different claims and this is exactly where a `\`-continuation mistake would hide
- [x] `cargo test -p cubism-core aggregate_state::` — 10/10 pass, including `corrupted_payload_is_rejected_rather_than_silently_decoded` which asserts on the `"failed its checksum"` substring
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo test --workspace --doc`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [x] All 6 example specs still validate (`cargo run -p cubism-cli -- validate`)
- [x] `lychee --offline --include-fragments` — 0 errors
- [ ] `maturin build` (Python bindings smoke) — **not run locally, maturin isn't installed in this environment.** `bindings/cubism-py` is untouched by this change; CI's `python` job covers it.