### PR TITLE
fix: reject count==0 with non-zero sum in AverageState::decode

### DIFF
--- a/crates/cubism-core/src/aggregate_state.rs
+++ b/crates/cubism-core/src/aggregate_state.rs
@@ -345,6 +345,11 @@ impl AggregateState for AverageState {
                 "decoded average sum is not finite".into(),
             ));
         }
+        if count == 0 && sum != 0.0 {
+            return Err(CubismError::AggregateState(
+                "empty average state must have zero sum".into(),
+            ));
+        }
         Ok(Self { sum, count })
     }
 
@@ -915,5 +920,39 @@ mod tests {
                 "a {keep}-byte prefix must not decode"
             );
         }
+    }
+
+    #[test]
+    fn average_rejects_zero_count_with_nonzero_sum() {
+        // An orphaned sum with count == 0 is semantically impossible: `mean`
+        // reports it as empty, but `merge` still folds the sum into every
+        // aggregate above it (issue #53). V1 carries no checksum by design,
+        // so this semantic check is the only defence on that path — cover
+        // both framing versions rather than just the harder-to-corrupt V2
+        // one, to prove it isn't short-circuited by the checksum path.
+        let mut v1 = Vec::new();
+        v1.extend_from_slice(AVG_MAGIC);
+        v1.push(FORMAT_V1);
+        v1.extend_from_slice(&1.5f64.to_le_bytes());
+        v1.extend_from_slice(&0u64.to_le_bytes());
+        let err = AverageState::decode(&v1).expect_err("v1 impossible state must be rejected");
+        assert!(
+            err.to_string()
+                .contains("empty average state must have zero sum"),
+            "unexpected error: {err}"
+        );
+
+        let mut v2 = Vec::new();
+        v2.extend_from_slice(AVG_MAGIC);
+        v2.push(FORMAT_V2);
+        v2.extend_from_slice(&1.5f64.to_le_bytes());
+        v2.extend_from_slice(&0u64.to_le_bytes());
+        let v2 = finish_v2(v2);
+        let err = AverageState::decode(&v2).expect_err("v2 impossible state must be rejected");
+        assert!(
+            err.to_string()
+                .contains("empty average state must have zero sum"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `AverageState::decode` validated only that `sum` is finite, accepting a semantically impossible state: `count == 0` with a non-zero `sum`.
- `mean()` treats zero count as empty, but `merge()` still folds the orphaned `sum` into the result — an impossible state presents as "no data" while silently contributing to every aggregate it merges into.
- V1 blobs carry no checksum by design, so this semantic check is the only defence on that decode path (the poisoning scenario #9's framing was introduced to prevent).
- Fix mirrors the equivalent check already present in `VarianceState::decode` (`aggregate_state.rs:489-493`) — same shape, same style.

## Audit (per the issue's "while in there" request)
- **`VarianceState`**: already has the analogous check (`count == 0 && (mean != 0.0 || m2 != 0.0)`) — no change needed.
- **`QuantileState`**: safe by construction — `decode` rejects `bin_count == 0` and requires `decoded_count == count`, so `count == 0` forces zero bins; no impossible state is representable. No change needed.

Closes #53

**This PR is the second execution of the repo's `.claude/skills/work-issue/` skill**, and the first since its mechanics were extracted into standalone scripts (`.claude/skills/work-issue/scripts/`). While running it, found and fixed a real guardrail bug in `check-merge-eligibility.sh` (it was reading `SDLC.md` from the PR's own worktree rather than the trusted main checkout) — that fix is deliberately **not** included in this PR; it's unrelated housekeeping on the skill infrastructure itself, tracked separately.

## Test plan
- [x] New test `average_rejects_zero_count_with_nonzero_sum` covers both V1 (no checksum — the actual attack surface) and V2 framing, confirming the check isn't short-circuited by the checksum path.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo test --workspace --doc`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`
- [x] All example specs still validate
- [x] `lychee --offline --include-fragments` — 0 errors
- [ ] `maturin build` (Python bindings smoke) — **not run locally, maturin isn't installed in this environment.** `bindings/cubism-py` is untouched by this change; CI's `python` job covers it.